### PR TITLE
Use Cloudinary uploads for user avatars

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class AuthController extends Controller
 {
@@ -77,7 +79,7 @@ class AuthController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Usuario creado correctamente',
-            'user' => $user
+            'user' => $this->formatUserResponse($user)
         ], 201);
     }
 
@@ -136,14 +138,7 @@ class AuthController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Login exitoso',
-            'user' => [
-                'id' => $user->id,
-                'name' => $user->name,
-                'email' => $user->email,
-                'role' => $user->role, // 🔥 asegurate de incluirlo
-                'created_at' => $user->created_at,
-                'updated_at' => $user->updated_at,
-            ],
+            'user' => $this->formatUserResponse($user),
             'token' => $token,
         ]);
         
@@ -185,15 +180,104 @@ class AuthController extends Controller
     }
 
     // Devuelve solo los campos necesarios o todo el usuario
-    return response()->json([
-        'id' => $user->id,
-        'name' => $user->name,
-        'email' => $user->email,
-        'role' => $user->role,
-        'created_at' => $user->created_at,
-        'updated_at' => $user->updated_at
-    ]);
+    return response()->json($this->formatUserResponse($user));
 }
+
+    public function updateProfile(Request $request)
+    {
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'name' => 'sometimes|string|max:100',
+            'email' => [
+                'sometimes',
+                'email',
+                Rule::unique('users', 'email')->ignore($user->id),
+            ],
+            'phone' => 'sometimes|nullable|string|max:30',
+            'bio' => 'sometimes|nullable|string|max:500',
+            'email_notifications' => 'sometimes|boolean',
+            'current_password' => 'required_with:password|string',
+            'password' => 'sometimes|string|min:8|confirmed',
+            'avatar_url' => 'sometimes|nullable|url|max:500',
+            'remove_avatar' => 'sometimes|boolean',
+        ]);
+
+        if (array_key_exists('current_password', $validated)) {
+            if (! Hash::check($validated['current_password'], $user->password)) {
+                return response()->json([
+                    'message' => 'La contraseña actual no coincide.',
+                ], 422);
+            }
+
+            unset($validated['current_password']);
+        }
+
+        if (array_key_exists('password', $validated)) {
+            $user->password = Hash::make($validated['password']);
+            unset($validated['password']);
+        }
+
+        $shouldRemoveAvatar = ! empty($validated['remove_avatar']);
+        unset($validated['remove_avatar']);
+
+        if ($shouldRemoveAvatar && $user->avatar_path) {
+            if (! Str::startsWith($user->avatar_path, ['http://', 'https://'])) {
+                Storage::disk('public')->delete($user->avatar_path);
+            }
+
+            $validated['avatar_path'] = null;
+        }
+
+        if (array_key_exists('avatar_url', $validated)) {
+            $newAvatarUrl = $validated['avatar_url'];
+            unset($validated['avatar_url']);
+
+            if ($newAvatarUrl) {
+                if ($user->avatar_path && ! Str::startsWith($user->avatar_path, ['http://', 'https://'])) {
+                    Storage::disk('public')->delete($user->avatar_path);
+                }
+
+                $validated['avatar_path'] = $newAvatarUrl;
+            } else {
+                $validated['avatar_path'] = null;
+            }
+        }
+
+        if (array_key_exists('phone', $validated) && $validated['phone'] === '') {
+            $validated['phone'] = null;
+        }
+
+        if (array_key_exists('bio', $validated) && trim((string) $validated['bio']) === '') {
+            $validated['bio'] = null;
+        }
+
+        $user->fill($validated);
+        $user->save();
+
+        return response()->json([
+            'message' => 'Perfil actualizado correctamente.',
+            'user' => $this->formatUserResponse($user->fresh()),
+        ]);
+    }
+
+    private function formatUserResponse(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'role' => $user->role,
+            'is_verified' => (bool) $user->is_verified,
+            'phone' => $user->phone,
+            'bio' => $user->bio,
+            'avatar_url' => $user->avatar_url,
+            'email_notifications' => (bool) $user->email_notifications,
+            'is_active' => (bool) $user->is_active,
+            'created_at' => $user->created_at,
+            'updated_at' => $user->updated_at,
+        ];
+    }
 
 
     /**

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -6,6 +6,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 // 👇 Importante para Sanctum
 use Laravel\Sanctum\HasApiTokens;
 
@@ -24,6 +26,19 @@ class User extends Authenticatable
         'password',
         'role',
         'is_active',
+        'phone',
+        'bio',
+        'avatar_path',
+        'email_notifications',
+    ];
+
+    /**
+     * Atributos calculados que deben incluirse en la serialización.
+     *
+     * @var list<string>
+     */
+    protected $appends = [
+        'avatar_url',
     ];
 
     /**
@@ -47,6 +62,24 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'is_active' => 'boolean',
+            'email_notifications' => 'boolean',
         ];
+    }
+
+    public function getAvatarUrlAttribute(): ?string
+    {
+        if (! $this->avatar_path) {
+            return null;
+        }
+
+        try {
+            if (Str::startsWith($this->avatar_path, ['http://', 'https://'])) {
+                return $this->avatar_path;
+            }
+
+            return Storage::disk('public')->url($this->avatar_path);
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 }

--- a/backend/database/migrations/2025_10_30_000000_add_profile_fields_to_users_table.php
+++ b/backend/database/migrations/2025_10_30_000000_add_profile_fields_to_users_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'phone')) {
+                $table->string('phone', 30)->nullable()->after('email');
+            }
+
+            if (!Schema::hasColumn('users', 'bio')) {
+                $table->text('bio')->nullable()->after('phone');
+            }
+
+            if (!Schema::hasColumn('users', 'avatar_path')) {
+                $table->string('avatar_path')->nullable()->after('bio');
+            }
+
+            if (!Schema::hasColumn('users', 'email_notifications')) {
+                $table->boolean('email_notifications')->default(true)->after('is_active');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'phone')) {
+                $table->dropColumn('phone');
+            }
+
+            if (Schema::hasColumn('users', 'bio')) {
+                $table->dropColumn('bio');
+            }
+
+            if (Schema::hasColumn('users', 'avatar_path')) {
+                $table->dropColumn('avatar_path');
+            }
+
+            if (Schema::hasColumn('users', 'email_notifications')) {
+                $table->dropColumn('email_notifications');
+            }
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -34,6 +34,7 @@ Route::middleware('auth:sanctum')->group(function () {
     // Usuario autenticado
     Route::get('/auth/me', [AuthController::class, 'me']);
     Route::post('/auth/logout', [AuthController::class, 'logout']);
+    Route::match(['put', 'patch'], '/auth/profile', [AuthController::class, 'updateProfile']);
     Route::post('/send-verification', [VerificationController::class, 'sendVerificationEmail']);
     Route::post('/request-admin', [VerificationController::class, 'requestAdmin']);
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -10,8 +10,9 @@ import { Checkout } from './pages/checkout/checkout';
 import { TicketScanner } from './pages/ticket-scanner/ticket-scanner';
 import { MyTickets } from './pages/my-tickets/my-tickets';
 import { VerifyAccount} from './pages/verify-account/verify-account';
-import { Verified } from './pages/verified/verified'; 
+import { Verified } from './pages/verified/verified';
 import { UserStats } from './pages/user-stats/user-stats';
+import { UserProfile } from './pages/user-profile/user-profile';
 export const routes: Routes = [
   { path: 'register', component: RegisterComponent },
   { path: 'login', component: Login },
@@ -24,7 +25,8 @@ export const routes: Routes = [
   { path: 'my-tickets', component: MyTickets },
   { path: 'verify-account', component: VerifyAccount },
   { path: 'verified', component: Verified },
-  { path: 'my-events', component: UserStats }
+  { path: 'my-events', component: UserStats },
+  { path: 'profile', component: UserProfile }
 ];
 
 @NgModule({

--- a/frontend/src/app/pages/navbar/navbar.html
+++ b/frontend/src/app/pages/navbar/navbar.html
@@ -59,6 +59,25 @@
       </div>
     </nav>
     <button
+      *ngIf="isLoggedIn"
+      (click)="goToProfile()"
+      class="inline-flex items-center bg-gray-800 border-0 py-1 px-3 focus:outline-none hover:text-black hover:bg-[#00d58b] rounded text-base mt-4 md:mt-0 mr-3"
+    >
+      <span class="relative flex items-center justify-center w-8 h-8 mr-2">
+        <img
+          *ngIf="avatarUrl; else defaultAvatar"
+          [src]="avatarUrl"
+          alt="Avatar"
+          class="w-8 h-8 rounded-full border border-[#00d58b]/60 object-cover"
+        />
+        <ng-template #defaultAvatar>
+          <fa-icon [icon]="faCircleUser" class="text-xl text-[#00d58b]"></fa-icon>
+        </ng-template>
+      </span>
+      <span class="hidden sm:inline">{{ userName || 'Mi perfil' }}</span>
+      <fa-icon [icon]="faGear" class="ml-2 text-sm"></fa-icon>
+    </button>
+    <button
       *ngIf="isLoggedIn && !isVerified && userRole != 'admin'"
       (click)="requestVerification()"
       [disabled]="loadingVerify"

--- a/frontend/src/app/pages/navbar/navbar.ts
+++ b/frontend/src/app/pages/navbar/navbar.ts
@@ -13,6 +13,8 @@ import {
   faRightFromBracket,
   faRightToBracket,
   faExclamation,
+  faCircleUser,
+  faGear,
 } from '@fortawesome/free-solid-svg-icons';
 @Component({
   selector: 'app-navbar',
@@ -29,6 +31,8 @@ export class NavbarComponent implements OnInit {
   isVerified: boolean = false;
   verifyMessage: string = '';
   loadingVerify: boolean = false;
+  userName: string = '';
+  avatarUrl: string | null = null;
 
   constructor(
     private router: Router,
@@ -60,6 +64,8 @@ export class NavbarComponent implements OnInit {
           if (user && user.email) {
             localStorage.setItem('email', user.email);
           }
+          this.userName = user?.name ?? '';
+          this.avatarUrl = user?.avatar_url ?? null;
         },
         error: () => this.logout(false),
       });
@@ -72,6 +78,8 @@ export class NavbarComponent implements OnInit {
   faRightFromBracket = faRightFromBracket;
   faRightToBracket = faRightToBracket;
   faExclamation = faExclamation;
+  faCircleUser = faCircleUser;
+  faGear = faGear;
 
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
@@ -98,6 +106,8 @@ export class NavbarComponent implements OnInit {
     this.isLoggedIn = false;
     this.userRole = '';
     this.isVerified = false;
+    this.userName = '';
+    this.avatarUrl = null;
     this.cdr.detectChanges();
     if (navigate) this.router.navigate(['/login']);
   }
@@ -122,5 +132,9 @@ export class NavbarComponent implements OnInit {
         this.loadingVerify = false;
       },
     });
+  }
+
+  goToProfile(): void {
+    this.navigate('/profile');
   }
 }

--- a/frontend/src/app/pages/user-profile/user-profile.html
+++ b/frontend/src/app/pages/user-profile/user-profile.html
@@ -1,0 +1,151 @@
+<app-navbar></app-navbar>
+<section class="profile-page">
+  <div class="wrapper">
+    <header class="profile-header">
+      <div class="avatar">
+        <img *ngIf="avatarPreview; else defaultAvatar" [src]="avatarPreview" alt="Avatar" />
+        <ng-template #defaultAvatar>
+          <div class="placeholder">{{ user?.name?.charAt(0) || 'U' }}</div>
+        </ng-template>
+      </div>
+      <div class="info">
+        <h1>{{ user?.name || 'Mi perfil' }}</h1>
+        <p class="email">{{ user?.email }}</p>
+        <p class="meta">
+          Miembro desde {{ user?.created_at | date: 'longDate' }} ·
+          <span [class.text-green]="user?.is_verified" [class.text-warning]="!user?.is_verified">
+            {{ user?.is_verified ? 'Cuenta verificada' : 'Cuenta pendiente de verificación' }}
+          </span>
+        </p>
+      </div>
+    </header>
+
+    <div class="grid">
+      <section class="card">
+        <div class="card-header">
+          <h2><fa-icon [icon]="faFloppyDisk"></fa-icon> Información personal</h2>
+          <button type="button" class="ghost" (click)="resetProfile()">
+            <fa-icon [icon]="faRotateLeft"></fa-icon>
+            Revertir cambios
+          </button>
+        </div>
+
+        <form [formGroup]="profileForm" (ngSubmit)="onProfileSubmit()" class="form">
+          <div class="feedback" *ngIf="successMessage">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ successMessage }}
+          </div>
+          <div class="feedback error" *ngIf="errorMessage">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ errorMessage }}
+          </div>
+
+          <label class="field">
+            <span>Nombre</span>
+            <input type="text" formControlName="name" placeholder="Tu nombre completo" />
+            <small *ngIf="profileForm.get('name')?.invalid && profileForm.get('name')?.touched">
+              Ingresá un nombre válido (máx. 100 caracteres).
+            </small>
+          </label>
+
+          <label class="field">
+            <span>Correo electrónico</span>
+            <input type="email" formControlName="email" placeholder="tucorreo@ejemplo.com" />
+            <small *ngIf="profileForm.get('email')?.invalid && profileForm.get('email')?.touched">
+              Ingresá un correo válido.
+            </small>
+          </label>
+
+          <div class="field-group">
+            <label class="field">
+              <span>Teléfono</span>
+              <input type="text" formControlName="phone" placeholder="Opcional" />
+            </label>
+            <label class="field">
+              <span>Notificaciones por correo</span>
+              <label class="toggle">
+                <input type="checkbox" formControlName="email_notifications" />
+                <span class="slider"></span>
+              </label>
+            </label>
+          </div>
+
+          <label class="field">
+            <span>Biografía</span>
+            <textarea formControlName="bio" rows="4" placeholder="Contale al resto quién sos o qué haces"></textarea>
+          </label>
+
+          <div class="avatar-uploader">
+            <div class="preview" [class.placeholder]="!avatarPreview">
+              <img *ngIf="avatarPreview" [src]="avatarPreview" alt="Vista previa" />
+              <span *ngIf="!avatarPreview">
+                <fa-icon [icon]="faCamera"></fa-icon>
+                Subí una foto (máx. 2 MB)
+              </span>
+            </div>
+            <div class="actions">
+              <label class="upload">
+                <input type="file" accept="image/*" (change)="onAvatarChange($event)" />
+                <fa-icon [icon]="faCamera"></fa-icon>
+                Cambiar avatar
+              </label>
+              <button type="button" class="ghost danger" (click)="clearAvatar()" [disabled]="!avatarPreview">
+                <fa-icon [icon]="faTrash"></fa-icon>
+                Quitar avatar
+              </button>
+            </div>
+          </div>
+
+          <button class="primary" type="submit" [disabled]="loadingProfile">
+            <span *ngIf="loadingProfile" class="loader"></span>
+            <fa-icon *ngIf="!loadingProfile" [icon]="faFloppyDisk"></fa-icon>
+            Guardar cambios
+          </button>
+        </form>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2><fa-icon [icon]="faShieldHalved"></fa-icon> Seguridad</h2>
+        </div>
+        <form [formGroup]="passwordForm" (ngSubmit)="onPasswordSubmit()" class="form">
+          <div class="feedback success" *ngIf="passwordMessage">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ passwordMessage }}
+          </div>
+          <div class="feedback error" *ngIf="passwordError">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ passwordError }}
+          </div>
+          <label class="field">
+            <span>Contraseña actual</span>
+            <input type="password" formControlName="current_password" placeholder="••••••••" />
+          </label>
+          <label class="field">
+            <span>Nueva contraseña</span>
+            <input type="password" formControlName="password" placeholder="Mínimo 8 caracteres" />
+          </label>
+          <label class="field">
+            <span>Confirmar contraseña</span>
+            <input type="password" formControlName="password_confirmation" placeholder="Repetí la nueva contraseña" />
+          </label>
+          <button class="primary" type="submit" [disabled]="loadingPassword">
+            <span *ngIf="loadingPassword" class="loader"></span>
+            <fa-icon *ngIf="!loadingPassword" [icon]="faLock"></fa-icon>
+            Actualizar contraseña
+          </button>
+        </form>
+
+        <div class="tips">
+          <h3><fa-icon [icon]="faBell"></fa-icon> Consejos rápidos</h3>
+          <ul>
+            <li>Usá una contraseña única y difícil de adivinar.</li>
+            <li>Activá las notificaciones para enterarte de tus compras y cambios importantes.</li>
+            <li>Mantené tus datos al día para recibir novedades relevantes.</li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+<app-footer></app-footer>

--- a/frontend/src/app/pages/user-profile/user-profile.scss
+++ b/frontend/src/app/pages/user-profile/user-profile.scss
@@ -1,0 +1,394 @@
+.profile-page {
+  min-height: calc(100vh - 140px);
+  background: radial-gradient(circle at 20% 20%, rgba(0, 213, 139, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(34, 211, 238, 0.08), transparent 60%),
+    #0b1120;
+  padding: 3rem 1.5rem;
+  color: #e2e8f0;
+
+  .wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .profile-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    background: linear-gradient(135deg, rgba(15, 118, 110, 0.6), rgba(7, 89, 133, 0.4));
+    box-shadow: 0 20px 45px rgba(2, 132, 199, 0.15);
+
+    .avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 50%;
+      overflow: hidden;
+      border: 3px solid rgba(16, 185, 129, 0.8);
+      background: rgba(15, 23, 42, 0.8);
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        font-size: 2.5rem;
+        font-weight: 600;
+        color: rgba(16, 185, 129, 0.9);
+      }
+    }
+
+    .info {
+      h1 {
+        font-size: clamp(1.6rem, 2.5vw, 2.1rem);
+        margin: 0;
+        color: #f8fafc;
+        font-weight: 700;
+      }
+
+      .email {
+        margin: 0.25rem 0;
+        color: rgba(226, 232, 240, 0.8);
+      }
+
+      .meta {
+        font-size: 0.9rem;
+        color: rgba(148, 163, 184, 0.9);
+
+        .text-green {
+          color: #4ade80;
+        }
+
+        .text-warning {
+          color: #facc15;
+        }
+      }
+    }
+  }
+
+  .grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+
+  .card {
+    background: rgba(15, 23, 42, 0.8);
+    border-radius: 1.25rem;
+    padding: 1.75rem;
+    border: 1px solid rgba(45, 212, 191, 0.08);
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
+    backdrop-filter: blur(8px);
+
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1.5rem;
+      gap: 1rem;
+
+      h2 {
+        font-size: 1.1rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        color: #f1f5f9;
+
+        fa-icon {
+          color: #2dd4bf;
+        }
+      }
+
+      .ghost {
+        background: rgba(14, 165, 233, 0.15);
+        color: #38bdf8;
+        border: 1px solid rgba(56, 189, 248, 0.35);
+        border-radius: 9999px;
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: all 0.25s ease;
+        cursor: pointer;
+
+        &:hover {
+          background: rgba(56, 189, 248, 0.25);
+          color: #0ea5e9;
+        }
+
+        &.danger {
+          border-color: rgba(248, 113, 113, 0.4);
+          color: #f87171;
+          background: rgba(239, 68, 68, 0.12);
+
+          &:hover {
+            background: rgba(239, 68, 68, 0.2);
+          }
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+      }
+    }
+
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 1.2rem;
+
+      .feedback {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.75rem 1rem;
+        border-radius: 0.85rem;
+        font-size: 0.9rem;
+        background: rgba(34, 197, 94, 0.12);
+        color: #86efac;
+
+        &.success {
+          background: rgba(22, 163, 74, 0.18);
+          color: #4ade80;
+        }
+
+        &.error {
+          background: rgba(248, 113, 113, 0.15);
+          color: #fca5a5;
+        }
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+
+        span {
+          font-size: 0.9rem;
+          color: rgba(148, 163, 184, 0.9);
+        }
+
+        input,
+        textarea {
+          background: rgba(15, 23, 42, 0.8);
+          border: 1px solid rgba(45, 212, 191, 0.15);
+          border-radius: 0.85rem;
+          padding: 0.75rem 1rem;
+          color: #e2e8f0;
+          transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+          &:focus {
+            border-color: rgba(16, 185, 129, 0.6);
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+          }
+        }
+
+        small {
+          color: #fda4af;
+          font-size: 0.75rem;
+        }
+      }
+
+      .field-group {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1rem;
+
+        @media (min-width: 640px) {
+          grid-template-columns: 1fr 1fr;
+        }
+
+        .toggle {
+          position: relative;
+          display: inline-flex;
+          align-items: center;
+          height: 42px;
+          padding: 0.5rem 0;
+
+          input {
+            display: none;
+          }
+
+          .slider {
+            width: 58px;
+            height: 30px;
+            background: rgba(148, 163, 184, 0.3);
+            border-radius: 999px;
+            position: relative;
+            transition: background 0.25s ease;
+
+            &::after {
+              content: '';
+              position: absolute;
+              width: 24px;
+              height: 24px;
+              border-radius: 999px;
+              background: #e2e8f0;
+              top: 3px;
+              left: 4px;
+              transition: transform 0.25s ease;
+            }
+          }
+
+          input:checked + .slider {
+            background: rgba(16, 185, 129, 0.45);
+
+            &::after {
+              transform: translateX(26px);
+              background: #10b981;
+            }
+          }
+        }
+      }
+
+      .avatar-uploader {
+        display: grid;
+        gap: 1rem;
+
+        .preview {
+          min-height: 150px;
+          border-radius: 1rem;
+          border: 1px dashed rgba(45, 212, 191, 0.35);
+          background: rgba(15, 23, 42, 0.6);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          overflow: hidden;
+
+          &.placeholder {
+            border-style: dashed;
+          }
+
+          img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+
+          span {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.35rem;
+            color: rgba(148, 163, 184, 0.9);
+
+            fa-icon {
+              font-size: 1.5rem;
+              color: #2dd4bf;
+            }
+          }
+        }
+
+        .actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.75rem;
+
+          .upload {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: rgba(34, 197, 94, 0.18);
+            color: #4ade80;
+            border: 1px solid rgba(34, 197, 94, 0.35);
+            border-radius: 999px;
+            padding: 0.5rem 1.25rem;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: all 0.2s ease;
+
+            input {
+              display: none;
+            }
+
+            &:hover {
+              background: rgba(34, 197, 94, 0.28);
+            }
+          }
+        }
+      }
+
+      .primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        background: linear-gradient(135deg, #10b981, #14b8a6);
+        color: #031c1f;
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.75rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+        &:hover {
+          transform: translateY(-1px);
+          box-shadow: 0 15px 30px rgba(20, 184, 166, 0.35);
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+          box-shadow: none;
+        }
+
+        .loader {
+          width: 16px;
+          height: 16px;
+          border: 3px solid rgba(3, 28, 31, 0.15);
+          border-top-color: #031c1f;
+          border-radius: 50%;
+          animation: spin 0.8s linear infinite;
+        }
+      }
+    }
+
+    .tips {
+      margin-top: 2rem;
+      padding: 1.25rem;
+      border-radius: 1rem;
+      background: rgba(14, 165, 233, 0.12);
+      border: 1px solid rgba(59, 130, 246, 0.18);
+
+      h3 {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        color: #bae6fd;
+        margin-bottom: 0.75rem;
+
+        fa-icon {
+          color: #38bdf8;
+        }
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 0.5rem;
+        font-size: 0.9rem;
+        color: rgba(224, 231, 255, 0.9);
+      }
+    }
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/app/pages/user-profile/user-profile.ts
+++ b/frontend/src/app/pages/user-profile/user-profile.ts
@@ -1,0 +1,264 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NavbarComponent } from '../navbar/navbar';
+import { FooterComponent } from '../footer/footer';
+import { AuthService, ProfileResponse, User } from '../../services/auth.service';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { HttpClient } from '@angular/common/http';
+import {
+  faCamera,
+  faFloppyDisk,
+  faRotateLeft,
+  faShieldHalved,
+  faLock,
+  faBell,
+  faTrash,
+  faCircleInfo,
+} from '@fortawesome/free-solid-svg-icons';
+import { Subscription, lastValueFrom } from 'rxjs';
+
+@Component({
+  selector: 'app-user-profile',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, NavbarComponent, FooterComponent, FontAwesomeModule],
+  templateUrl: './user-profile.html',
+  styleUrls: ['./user-profile.scss'],
+})
+export class UserProfile implements OnInit, OnDestroy {
+  profileForm: FormGroup;
+  passwordForm: FormGroup;
+  user: User | null = null;
+  loadingProfile = false;
+  loadingPassword = false;
+  successMessage: string | null = null;
+  passwordMessage: string | null = null;
+  errorMessage: string | null = null;
+  passwordError: string | null = null;
+  avatarPreview: string | null = null;
+  avatarFile: File | null = null;
+  removeAvatar = false;
+  private subscriptions: Subscription[] = [];
+  private initialProfile: Partial<User> | null = null;
+
+  // Icons
+  faCamera = faCamera;
+  faFloppyDisk = faFloppyDisk;
+  faRotateLeft = faRotateLeft;
+  faShieldHalved = faShieldHalved;
+  faLock = faLock;
+  faBell = faBell;
+  faTrash = faTrash;
+  faCircleInfo = faCircleInfo;
+
+  private readonly cloudinaryUploadUrl = 'https://api.cloudinary.com/v1_1/da80v8vj1/image/upload';
+  private readonly cloudinaryUploadPreset = 'utnentradas';
+
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthService,
+    private http: HttpClient
+  ) {
+    this.profileForm = this.fb.group({
+      name: ['', [Validators.required, Validators.maxLength(100)]],
+      email: ['', [Validators.required, Validators.email]],
+      phone: ['', [Validators.maxLength(30)]],
+      bio: ['', [Validators.maxLength(500)]],
+      email_notifications: [true],
+    });
+
+    this.passwordForm = this.fb.group({
+      current_password: ['', [Validators.required]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      password_confirmation: ['', [Validators.required, Validators.minLength(8)]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadProfile();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+  }
+
+  loadProfile(): void {
+    const sub = this.authService.getUser().subscribe({
+      next: (user) => {
+        this.user = user;
+        this.initialProfile = { ...user };
+        this.avatarPreview = user.avatar_url;
+        this.avatarFile = null;
+        this.removeAvatar = false;
+        this.profileForm.patchValue({
+          name: user.name,
+          email: user.email,
+          phone: user.phone || '',
+          bio: user.bio || '',
+          email_notifications: user.email_notifications,
+        });
+      },
+      error: () => {
+        this.errorMessage = 'No se pudo cargar tu perfil. Intenta nuevamente.';
+      },
+    });
+
+    this.subscriptions.push(sub);
+  }
+
+  async onProfileSubmit(): Promise<void> {
+    if (this.profileForm.invalid) {
+      this.profileForm.markAllAsTouched();
+      return;
+    }
+
+    this.loadingProfile = true;
+    this.successMessage = null;
+    this.errorMessage = null;
+
+    const values = this.profileForm.value;
+    const payload: any = {
+      name: values.name,
+      email: values.email,
+      phone: values.phone ?? '',
+      bio: values.bio ?? '',
+      email_notifications: !!values.email_notifications,
+    };
+
+    if (typeof payload.phone === 'string' && payload.phone.trim() === '') {
+      payload.phone = null;
+    }
+
+    if (typeof payload.bio === 'string' && payload.bio.trim() === '') {
+      payload.bio = null;
+    }
+
+    if (this.removeAvatar) {
+      payload.remove_avatar = true;
+    }
+
+    try {
+      if (this.avatarFile) {
+        const cloudinaryData = new FormData();
+        cloudinaryData.append('file', this.avatarFile);
+        cloudinaryData.append('upload_preset', this.cloudinaryUploadPreset);
+
+        const uploadResponse: any = await lastValueFrom(
+          this.http.post(this.cloudinaryUploadUrl, cloudinaryData)
+        );
+
+        payload.avatar_url = uploadResponse.secure_url;
+      }
+
+      const res: ProfileResponse = await lastValueFrom(this.authService.updateProfile(payload));
+
+      this.successMessage = res.message || 'Perfil actualizado correctamente.';
+      this.user = res.user;
+      this.initialProfile = { ...res.user };
+      this.profileForm.patchValue({
+        name: res.user.name,
+        email: res.user.email,
+        phone: res.user.phone || '',
+        bio: res.user.bio || '',
+        email_notifications: res.user.email_notifications,
+      });
+
+      if (this.avatarPreview && this.avatarFile) {
+        URL.revokeObjectURL(this.avatarPreview);
+      }
+
+      this.avatarPreview = res.user.avatar_url;
+      this.avatarFile = null;
+      this.removeAvatar = false;
+    } catch (err: any) {
+      this.errorMessage = err?.error?.message || 'No se pudo actualizar el perfil.';
+    } finally {
+      this.loadingProfile = false;
+    }
+  }
+
+  onPasswordSubmit(): void {
+    this.passwordError = null;
+    this.passwordMessage = null;
+
+    if (this.passwordForm.invalid) {
+      this.passwordForm.markAllAsTouched();
+      return;
+    }
+
+    const { current_password, password, password_confirmation } = this.passwordForm.value;
+    if (password !== password_confirmation) {
+      this.passwordError = 'Las contraseñas nuevas no coinciden.';
+      return;
+    }
+
+    this.loadingPassword = true;
+
+    const sub = this.authService
+      .updateProfile({ current_password, password, password_confirmation })
+      .subscribe({
+        next: (res) => {
+          this.loadingPassword = false;
+          this.passwordMessage = res.message || 'Contraseña actualizada correctamente.';
+          this.passwordForm.reset();
+        },
+        error: (err) => {
+          this.loadingPassword = false;
+          this.passwordError = err.error?.message || 'No se pudo actualizar la contraseña.';
+        },
+      });
+
+    this.subscriptions.push(sub);
+  }
+
+  onAvatarChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+
+    this.avatarFile = file;
+    this.avatarPreview = URL.createObjectURL(file);
+    this.removeAvatar = false;
+  }
+
+  clearAvatar(): void {
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+
+    this.avatarFile = null;
+    this.avatarPreview = null;
+    this.removeAvatar = true;
+  }
+
+  resetProfile(): void {
+    if (!this.initialProfile) {
+      return;
+    }
+
+    this.profileForm.patchValue({
+      name: this.initialProfile.name ?? '',
+      email: this.initialProfile.email ?? '',
+      phone: this.initialProfile.phone ?? '',
+      bio: this.initialProfile.bio ?? '',
+      email_notifications: this.initialProfile.email_notifications ?? true,
+    });
+    this.errorMessage = null;
+    this.successMessage = null;
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+    this.avatarFile = null;
+    this.avatarPreview = this.initialProfile.avatar_url ?? null;
+    this.removeAvatar = false;
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -9,6 +9,11 @@ export interface User {
   email: string;
   role: string;
   is_verified: boolean;
+  phone: string | null;
+  bio: string | null;
+  avatar_url: string | null;
+  email_notifications: boolean;
+  is_active: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -23,32 +28,38 @@ export interface RegisterResponse {
   user: User;
 }
 
+export interface ProfileResponse {
+  message: string;
+  user: User;
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  private apiUrl = 'http://localhost:8000/api/auth';
+  private readonly baseUrl = 'http://localhost:8000/api';
+  private readonly authUrl = `${this.baseUrl}/auth`;
 
   constructor(private http: HttpClient) {}
 
   register(data: { name: string; email: string; password: string }): Observable<RegisterResponse> {
-    return this.http.post<RegisterResponse>(`${this.apiUrl}/register`, data).pipe(
+    return this.http.post<RegisterResponse>(`${this.authUrl}/register`, data).pipe(
       tap((res: RegisterResponse) => {
         localStorage.setItem('token', res.token);
         localStorage.setItem('userId', res.user.id.toString());
         localStorage.setItem('role', res.user.role);
-        localStorage.setItem('email', res.user.email); 
+        localStorage.setItem('email', res.user.email);
       })
     );
   }
 
   login(data: { email: string; password: string }): Observable<LoginResponse> {
-    return this.http.post<LoginResponse>(`${this.apiUrl}/login`, data).pipe(
+    return this.http.post<LoginResponse>(`${this.authUrl}/login`, data).pipe(
       tap((res: LoginResponse) => {
         localStorage.setItem('token', res.token);
         localStorage.setItem('userId', res.user.id.toString());
         localStorage.setItem('role', res.user.role);
-        localStorage.setItem('email', res.user.email); 
+        localStorage.setItem('email', res.user.email);
       })
     );
   }
@@ -57,12 +68,39 @@ export class AuthService {
     localStorage.removeItem('token');
     localStorage.removeItem('userId');
     localStorage.removeItem('role');
-    localStorage.removeItem('email'); 
+    localStorage.removeItem('email');
   }
 
   getUser(): Observable<User> {
     const token = localStorage.getItem('token') || '';
     const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
-    return this.http.get<User>(`${this.apiUrl}/me`, { headers });
+    return this.http.get<User>(`${this.authUrl}/me`, { headers });
+  }
+
+  updateProfile(data: FormData | Partial<User> & {
+    current_password?: string;
+    password?: string;
+    password_confirmation?: string;
+    remove_avatar?: boolean;
+  }): Observable<ProfileResponse> {
+    const token = localStorage.getItem('token') || '';
+    let headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
+
+    const body = data instanceof FormData ? data : JSON.stringify(data);
+    if (!(data instanceof FormData)) {
+      headers = headers.set('Content-Type', 'application/json');
+    }
+
+    return this.http.request<ProfileResponse>('PATCH', `${this.authUrl}/profile`, {
+      body,
+      headers,
+    }).pipe(
+      tap((res) => {
+        if (res?.user) {
+          localStorage.setItem('role', res.user.role);
+          localStorage.setItem('email', res.user.email);
+        }
+      })
+    );
   }
 }


### PR DESCRIPTION
## Summary
- send profile avatar updates to Cloudinary from the Angular profile page
- persist Cloudinary avatar URLs in the backend and surface them in responses
- clean up old local avatar files when replacing them with Cloudinary assets

## Testing
- npm run build *(fails: Angular CLI budget limit on the existing initial bundle size)*

------
https://chatgpt.com/codex/tasks/task_e_690a11f17e088332837159dcb36474ab