### PR TITLE
Apply neo profile styling across pages

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -6,6 +6,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 // 👇 Importante para Sanctum
 use Laravel\Sanctum\HasApiTokens;
 
@@ -24,6 +26,19 @@ class User extends Authenticatable
         'password',
         'role',
         'is_active',
+        'phone',
+        'bio',
+        'avatar_path',
+        'email_notifications',
+    ];
+
+    /**
+     * Atributos calculados que deben incluirse en la serialización.
+     *
+     * @var list<string>
+     */
+    protected $appends = [
+        'avatar_url',
     ];
 
     /**
@@ -47,6 +62,24 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'is_active' => 'boolean',
+            'email_notifications' => 'boolean',
         ];
+    }
+
+    public function getAvatarUrlAttribute(): ?string
+    {
+        if (! $this->avatar_path) {
+            return null;
+        }
+
+        try {
+            if (Str::startsWith($this->avatar_path, ['http://', 'https://'])) {
+                return $this->avatar_path;
+            }
+
+            return Storage::disk('public')->url($this->avatar_path);
+        } catch (\Throwable $e) {
+            return null;
+        }
     }
 }

--- a/backend/database/migrations/2025_10_30_000000_add_profile_fields_to_users_table.php
+++ b/backend/database/migrations/2025_10_30_000000_add_profile_fields_to_users_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'phone')) {
+                $table->string('phone', 30)->nullable()->after('email');
+            }
+
+            if (!Schema::hasColumn('users', 'bio')) {
+                $table->text('bio')->nullable()->after('phone');
+            }
+
+            if (!Schema::hasColumn('users', 'avatar_path')) {
+                $table->string('avatar_path')->nullable()->after('bio');
+            }
+
+            if (!Schema::hasColumn('users', 'email_notifications')) {
+                $table->boolean('email_notifications')->default(true)->after('is_active');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'phone')) {
+                $table->dropColumn('phone');
+            }
+
+            if (Schema::hasColumn('users', 'bio')) {
+                $table->dropColumn('bio');
+            }
+
+            if (Schema::hasColumn('users', 'avatar_path')) {
+                $table->dropColumn('avatar_path');
+            }
+
+            if (Schema::hasColumn('users', 'email_notifications')) {
+                $table->dropColumn('email_notifications');
+            }
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -34,6 +34,7 @@ Route::middleware('auth:sanctum')->group(function () {
     // Usuario autenticado
     Route::get('/auth/me', [AuthController::class, 'me']);
     Route::post('/auth/logout', [AuthController::class, 'logout']);
+    Route::match(['put', 'patch'], '/auth/profile', [AuthController::class, 'updateProfile']);
     Route::post('/send-verification', [VerificationController::class, 'sendVerificationEmail']);
     Route::post('/request-admin', [VerificationController::class, 'requestAdmin']);
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -10,8 +10,9 @@ import { Checkout } from './pages/checkout/checkout';
 import { TicketScanner } from './pages/ticket-scanner/ticket-scanner';
 import { MyTickets } from './pages/my-tickets/my-tickets';
 import { VerifyAccount} from './pages/verify-account/verify-account';
-import { Verified } from './pages/verified/verified'; 
+import { Verified } from './pages/verified/verified';
 import { UserStats } from './pages/user-stats/user-stats';
+import { UserProfile } from './pages/user-profile/user-profile';
 export const routes: Routes = [
   { path: 'register', component: RegisterComponent },
   { path: 'login', component: Login },
@@ -24,7 +25,8 @@ export const routes: Routes = [
   { path: 'my-tickets', component: MyTickets },
   { path: 'verify-account', component: VerifyAccount },
   { path: 'verified', component: Verified },
-  { path: 'my-events', component: UserStats }
+  { path: 'my-events', component: UserStats },
+  { path: 'profile', component: UserProfile }
 ];
 
 @NgModule({

--- a/frontend/src/app/auth/login/login.html
+++ b/frontend/src/app/auth/login/login.html
@@ -1,66 +1,70 @@
-<div
-  class="login-container bg-[#0a0a0a] min-h-screen flex flex-col items-center justify-center px-6 py-10"
->
-  <div
-    class="border-[#00d58b] border-2 bg-black p-8 rounded-3xl shadow-[0_0_30px_#00d58b80] max-w-md w-full text-center transform transition-all duration-300 hover:scale-125"
-  >
-    <h2
-      class="text-3xl font-extrabold text-[#00d58b] mb-6 drop-shadow-lg flex items-center justify-center gap-2"
-    >
-      Login
-    </h2>
+<app-navbar></app-navbar>
 
-    <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-4">
-      <div class="input-group flex flex-col text-left">
-        <label for="email" class="text-gray-400 mb-1">Correo</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faEnvelope" class="text-[#00d58b]"></fa-icon>
-          <input
-            id="email"
-            type="email"
-            formControlName="email"
-            placeholder="Ingresa tu email"
-            class="w-full p-2 rounded-lg bg-[#0f0f0f] text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
+<section class="neo-page neo-page--full auth-page">
+  <div class="neo-wrapper neo-wrapper--narrow auth-wrapper">
+    <article class="neo-card neo-card--accent auth-card">
+      <header class="neo-card__header">
+        <span class="neo-card__eyebrow">Bienvenido nuevamente</span>
+        <h1 class="neo-card__title">Iniciar sesión</h1>
+        <p class="neo-card__subtitle">
+          Accedé a tu cuenta para seguir tus compras, gestionar tus eventos y descubrir nuevas experiencias.
+        </p>
+      </header>
+
+      <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="neo-form auth-form">
+        <label class="neo-field">
+          <span>Correo electrónico</span>
+          <div class="neo-field__control">
+            <fa-icon [icon]="faEnvelope" class="neo-field__icon"></fa-icon>
+            <input
+              id="email"
+              type="email"
+              formControlName="email"
+              placeholder="tucorreo@ejemplo.com"
+            />
+          </div>
+          <small *ngIf="loginForm.get('email')?.invalid && loginForm.get('email')?.touched">
+            Ingresá un correo válido.
+          </small>
+        </label>
+
+        <label class="neo-field">
+          <span>Contraseña</span>
+          <div class="neo-field__control">
+            <fa-icon [icon]="faLock" class="neo-field__icon"></fa-icon>
+            <input
+              id="password"
+              type="password"
+              formControlName="password"
+              placeholder="Tu contraseña segura"
+            />
+          </div>
+          <small *ngIf="loginForm.get('password')?.invalid && loginForm.get('password')?.touched">
+            La contraseña debe tener al menos 8 caracteres.
+          </small>
+        </label>
+
+        <div class="auth-links">
+          <a href="#" class="neo-link neo-link--ghost">¿Olvidaste tu contraseña?</a>
         </div>
-      </div>
 
-      <div class="input-group flex flex-col text-left">
-        <label for="password" class="text-gray-400 mb-1">Contraseña</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faLock" class="text-[#00d58b]"></fa-icon>
-          <input
-            id="password"
-            type="password"
-            formControlName="password"
-            placeholder="Ingresa tu contraseña"
-            class="w-full p-2 rounded-lg bg-[#0f0f0f] text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
+        <div *ngIf="errorMessage" class="neo-feedback neo-feedback--error">
+          <fa-icon [icon]="faExclamationCircle"></fa-icon>
+          {{ errorMessage }}
         </div>
-      </div>
 
-      <a href="#" class="text-sm text-[#00d58b] hover:underline self-end"
-        >¿Olvidaste tu contraseña?</a
-      >
+        <button type="submit" class="neo-button neo-button--primary" [disabled]="loginForm.invalid">
+          Ingresar
+          <fa-icon [icon]="faArrowRight"></fa-icon>
+        </button>
 
-      <button
-        type="submit"
-        [disabled]="loginForm.invalid"
-        class="w-full bg-[#00d58b] py-3 rounded-full font-semibold text-black flex justify-center items-center gap-2 hover:opacity-90 transition-all"
-      >
-        Ingresar
-        <fa-icon [icon]="faArrowRight" class="text-black"></fa-icon>
-      </button>
-
-      <p class="text-gray-400 text-sm text-center">
-        ¿No tienes cuenta?
-        <a routerLink="/register" class="text-[#00d58b] hover:underline">Registrate</a>
-      </p>
-
-      <p *ngIf="errorMessage" class="text-red-500 text-sm flex items-center justify-center gap-2">
-        <fa-icon [icon]="faExclamationCircle"></fa-icon>
-        {{ errorMessage }}
-      </p>
-    </form>
+        <p class="neo-text--muted auth-helper">
+          ¿No tenés cuenta?
+          <a routerLink="/register" class="neo-link">Registrate</a>
+        </p>
+      </form>
+    </article>
   </div>
-</div>
+</section>
+
+<app-footer></app-footer>

--- a/frontend/src/app/auth/login/login.scss
+++ b/frontend/src/app/auth/login/login.scss
@@ -1,1 +1,33 @@
+.auth-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2rem;
 
+  .auth-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+
+  .auth-card {
+    width: 100%;
+  }
+
+  .auth-links {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .auth-helper {
+    text-align: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-page {
+    .auth-links {
+      justify-content: center;
+    }
+  }
+}

--- a/frontend/src/app/auth/login/login.ts
+++ b/frontend/src/app/auth/login/login.ts
@@ -4,18 +4,14 @@ import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService, LoginResponse } from '../../services/auth.service';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import {
-  faEnvelope,
-  faLock,
-  faCheckCircle,
-  faExclamationCircle,
-  faArrowRight,
-} from '@fortawesome/free-solid-svg-icons';
+import { faEnvelope, faLock, faExclamationCircle, faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import { NavbarComponent } from '../../pages/navbar/navbar';
+import { FooterComponent } from '../../pages/footer/footer';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, RouterModule, FontAwesomeModule],
+  imports: [ReactiveFormsModule, CommonModule, RouterModule, FontAwesomeModule, NavbarComponent, FooterComponent],
   templateUrl: './login.html',
   styleUrls: ['./login.scss'],
 })
@@ -24,7 +20,6 @@ export class Login {
   errorMessage: string | null = null;
   faEnvelope = faEnvelope;
   faLock = faLock;
-  faCheckCircle = faCheckCircle;
   faExclamationCircle = faExclamationCircle;
   faArrowRight = faArrowRight;
 

--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -1,125 +1,83 @@
-<div
-  class="register-container bg-[#0a0a0a] min-h-screen flex flex-col items-center justify-center px-6 py-10"
->
-  <div
-    class="bg-black-900 border-[#00d58b] border-2 p-8 rounded-3xl shadow-[0_0_30px_#00d58b80] max-w-md w-full text-center transform transition-all duration-300 hover:scale-125"
-  >
-    <h2
-      class="text-3xl font-extrabold text-[#00d58b] mb-6 drop-shadow-lg flex items-center justify-center gap-2"
-    >
-      Registrarse
-    </h2>
+<app-navbar></app-navbar>
 
-    <form [formGroup]="registerForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-4">
-      <!-- Nombre -->
-      <div class="input-group flex flex-col text-left">
-        <label for="name" class="text-gray-400 mb-1">Nombre</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faUserShield" class="text-[#00d58b]"></fa-icon>
-          <input
-            id="name"
-            type="text"
-            formControlName="name"
-            placeholder="Tu nombre"
-            class="w-full p-2 rounded-lg bg-[#0f0f0f] text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
-        </div>
-        <p
-          *ngIf="registerForm.get('name')?.invalid && registerForm.get('name')?.touched"
-          class="text-red-500 text-sm flex items-center gap-2"
-        >
-          <fa-icon [icon]="faTimesCircle"></fa-icon>
-          El nombre es obligatorio y debe tener al menos 3 caracteres
+<section class="neo-page neo-page--full auth-page">
+  <div class="neo-wrapper neo-wrapper--narrow auth-wrapper">
+    <article class="neo-card neo-card--accent auth-card">
+      <header class="neo-card__header">
+        <span class="neo-card__eyebrow">Sumate a la experiencia</span>
+        <h1 class="neo-card__title">Crear cuenta</h1>
+        <p class="neo-card__subtitle">
+          Organizá tus eventos, comprá tickets y guardá tus preferencias en un solo lugar.
         </p>
-      </div>
+      </header>
 
-      <!-- Email -->
-      <div class="input-group flex flex-col text-left">
-        <label for="email" class="text-gray-400 mb-1">Email</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faEnvelope" class="text-[#00d58b]"></fa-icon>
-          <input
-            id="email"
-            type="email"
-            formControlName="email"
-            placeholder="correo@ejemplo.com"
-            class="w-full p-2 rounded-lg bg-[#0f0f0f] text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
+      <form [formGroup]="registerForm" (ngSubmit)="onSubmit()" class="neo-form auth-form">
+        <label class="neo-field">
+          <span>Nombre completo</span>
+          <div class="neo-field__control">
+            <fa-icon [icon]="faUserShield" class="neo-field__icon"></fa-icon>
+            <input id="name" type="text" formControlName="name" placeholder="Tu nombre" />
+          </div>
+          <small *ngIf="registerForm.get('name')?.invalid && registerForm.get('name')?.touched">
+            El nombre es obligatorio y debe tener al menos 3 caracteres.
+          </small>
+        </label>
+
+        <label class="neo-field">
+          <span>Correo electrónico</span>
+          <div class="neo-field__control">
+            <fa-icon [icon]="faEnvelope" class="neo-field__icon"></fa-icon>
+            <input id="email" type="email" formControlName="email" placeholder="correo@ejemplo.com" />
+          </div>
+          <small *ngIf="registerForm.get('email')?.invalid && registerForm.get('email')?.touched">
+            Debe ser un correo válido.
+          </small>
+        </label>
+
+        <label class="neo-field">
+          <span>Contraseña</span>
+          <div class="neo-field__control">
+            <fa-icon [icon]="faLock" class="neo-field__icon"></fa-icon>
+            <input id="password" type="password" formControlName="password" placeholder="Mínimo 8 caracteres" />
+          </div>
+          <small *ngIf="registerForm.get('password')?.invalid && registerForm.get('password')?.touched">
+            La contraseña debe tener al menos 8 caracteres.
+          </small>
+        </label>
+
+        <label class="neo-field">
+          <span>Confirmar contraseña</span>
+          <div class="neo-field__control">
+            <fa-icon [icon]="faCheckDouble" class="neo-field__icon"></fa-icon>
+            <input
+              id="password_confirmation"
+              type="password"
+              formControlName="password_confirmation"
+              placeholder="Repetí tu contraseña"
+            />
+          </div>
+          <small *ngIf="registerForm.errors?.['mismatch'] && registerForm.get('password_confirmation')?.touched">
+            Las contraseñas no coinciden.
+          </small>
+        </label>
+
+        <div *ngIf="errorMessage" class="neo-feedback neo-feedback--error">
+          <fa-icon [icon]="faExclamationCircle"></fa-icon>
+          {{ errorMessage }}
         </div>
-        <p
-          *ngIf="registerForm.get('email')?.invalid && registerForm.get('email')?.touched"
-          class="text-red-500 text-sm flex items-center gap-2"
-        >
-          <fa-icon [icon]="faTimesCircle"></fa-icon>
-          Debe ser un email válido
+
+        <button type="submit" class="neo-button neo-button--primary" [disabled]="registerForm.invalid">
+          Crear cuenta
+          <fa-icon [icon]="faCheckCircle"></fa-icon>
+        </button>
+
+        <p class="neo-text--muted auth-helper">
+          ¿Ya tenés cuenta?
+          <a routerLink="/login" class="neo-link">Iniciá sesión</a>
         </p>
-      </div>
-
-      <!-- Password -->
-      <div class="input-group flex flex-col text-left">
-        <label for="password" class="text-gray-400 mb-1">Contraseña</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faLock" class="text-[#00d58b]"></fa-icon>
-          <input
-            id="password"
-            type="password"
-            formControlName="password"
-            placeholder="********"
-            class="w-full p-2 rounded-lg bg-[#0f0f0f] text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
-        </div>
-        <p
-          *ngIf="registerForm.get('password')?.invalid && registerForm.get('password')?.touched"
-          class="text-red-500 text-sm flex items-center gap-2"
-        >
-          <fa-icon [icon]="faTimesCircle"></fa-icon>
-          La contraseña debe tener al menos 8 caracteres
-        </p>
-      </div>
-
-      <!-- Password confirmation -->
-      <div class="input-group flex flex-col text-left">
-        <label for="password_confirmation" class="text-gray-400 mb-1">Confirmar contraseña</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faCheckDouble" class="text-[#00d58b]"></fa-icon>
-          <input
-            id="password_confirmation"
-            type="password"
-            formControlName="password_confirmation"
-            placeholder="********"
-            class="w-full p-2 rounded-lg bg-[#0f0f0f] text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-          />
-        </div>
-        <p
-          *ngIf="registerForm.errors?.['mismatch'] && registerForm.get('password_confirmation')?.touched"
-          class="text-red-500 text-sm flex items-center gap-2"
-        >
-          <fa-icon [icon]="faTimesCircle"></fa-icon>
-          Las contraseñas no coinciden
-        </p>
-      </div>
-
-      <button
-        type="submit"
-        [disabled]="registerForm.invalid"
-        class="mt-4 w-full bg-[#00d58b] py-3 rounded-full font-semibold text-white flex justify-center items-center gap-2 hover:opacity-90 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        Registrarse
-        <fa-icon [icon]="faCheckCircle"></fa-icon>
-      </button>
-    </form>
-
-    <p class="text-gray-400 text-sm text-center mt-2">
-      ¿Ya tenés cuenta?
-      <a routerLink="/login" class="text-[#00d58b] hover:underline">Inicia sesión</a>
-    </p>
-
-    <p
-      *ngIf="errorMessage"
-      class="text-red-500 text-sm flex items-center justify-center gap-2 mt-2"
-    >
-      <fa-icon [icon]="faExclamationCircle"></fa-icon>
-      {{ errorMessage }}
-    </p>
+      </form>
+    </article>
   </div>
-</div>
+</section>
+
+<app-footer></app-footer>

--- a/frontend/src/app/auth/register/register.component.ts
+++ b/frontend/src/app/auth/register/register.component.ts
@@ -4,20 +4,14 @@ import { RouterModule, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../services/auth.service';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import {
-  faUserShield,
-  faEnvelope,
-  faLock,
-  faTimesCircle,
-  faCheckCircle,
-  faExclamationCircle,
-  faCheckDouble,
-} from '@fortawesome/free-solid-svg-icons';
+import { faUserShield, faEnvelope, faLock, faCheckCircle, faExclamationCircle, faCheckDouble } from '@fortawesome/free-solid-svg-icons';
+import { NavbarComponent } from '../../pages/navbar/navbar';
+import { FooterComponent } from '../../pages/footer/footer';
 
 @Component({
   selector: 'app-register',
   standalone: true,
-  imports: [ReactiveFormsModule, CommonModule, RouterModule, FontAwesomeModule],
+  imports: [ReactiveFormsModule, CommonModule, RouterModule, FontAwesomeModule, NavbarComponent, FooterComponent],
   templateUrl: './register.component.html',
   styleUrls: ['./register.scss'],
 })
@@ -27,7 +21,6 @@ export class RegisterComponent {
   faUserShield = faUserShield;
   faEnvelope = faEnvelope;
   faLock = faLock;
-  faTimesCircle = faTimesCircle;
   faCheckCircle = faCheckCircle;
   faExclamationCircle = faExclamationCircle;
   faCheckDouble = faCheckDouble;

--- a/frontend/src/app/auth/register/register.scss
+++ b/frontend/src/app/auth/register/register.scss
@@ -1,0 +1,28 @@
+.auth-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2rem;
+
+  .auth-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+
+  .auth-card {
+    width: 100%;
+  }
+
+  .auth-helper {
+    text-align: center;
+  }
+}
+
+@media (max-width: 640px) {
+  .auth-page {
+    .auth-card {
+      padding: 1.5rem;
+    }
+  }
+}

--- a/frontend/src/app/pages/create-event/create-event.html
+++ b/frontend/src/app/pages/create-event/create-event.html
@@ -1,193 +1,84 @@
 <app-navbar></app-navbar>
 
-<!--<div
-  class="scanner-container min-h-screen max-w-2xl mx-auto bg-gradient-to-b from-[#002e35] to-[#0a0a0a] text-gray-200 p-8 rounded-2xl mt-10 shadow-xl border border-[#00d58b]/20"
->
-  <h2
-    class="text-3xl font-bold text-center mb-6 bg-gradient-to-r from-[#00d58b] to-[#92fa87] bg-clip-text text-transparent"
-  >
-    Crear Nuevo Evento
-  </h2>
+<section class="neo-page neo-page--with-nav create-event-page">
+  <div class="neo-wrapper neo-wrapper--medium">
+    <article class="neo-card neo-card--accent">
+      <header class="neo-card__header">
+        <span class="neo-card__eyebrow">Organizá tu próximo encuentro</span>
+        <h1 class="neo-card__title">Crear nuevo evento</h1>
+        <p class="neo-card__subtitle">
+          Completá la información clave para publicar un evento atractivo. Podrás editarlo en cualquier momento.
+        </p>
+      </header>
 
-  <form [formGroup]="eventForm" (ngSubmit)="onSubmit()" class="space-y-4">
-    <!-- Título 
-    <div>
-      <label class="block mb-1 font-semibold text-[#92fa87]">Título</label>
-      <input
-        formControlName="title"
-        class="w-full p-3 rounded-lg bg-[#001a1f] border border-[#00d58b]/30 focus:ring-2 focus:ring-[#00d58b] focus:outline-none"
-      />
-    </div>
+      <form [formGroup]="eventForm" (ngSubmit)="onSubmit()" class="neo-form create-event-form">
+        <div class="neo-form__grid">
+          <label class="neo-field neo-field--full">
+            <span>Título del evento</span>
+            <div class="neo-field__control">
+              <input formControlName="title" placeholder="Ej. Concierto sinfónico en vivo" />
+            </div>
+          </label>
 
-    <!-- Descripción 
-    <div>
-      <label class="block mb-1 font-semibold text-[#92fa87]">Descripción</label>
-      <textarea
-        formControlName="description"
-        rows="3"
-        class="w-full p-3 rounded-lg bg-[#001a1f] border border-[#00d58b]/30 focus:ring-2 focus:ring-[#00d58b] focus:outline-none"
-      ></textarea>
-    </div>
+          <label class="neo-field neo-field--full">
+            <span>Descripción</span>
+            <div class="neo-field__control">
+              <textarea rows="4" formControlName="description" placeholder="Contá en qué consiste tu evento"></textarea>
+            </div>
+          </label>
 
-    <!-- Fecha y hora / Capacidad 
-    <div class="grid sm:grid-cols-2 gap-4">
-      <div>
-        <label class="block mb-1 font-semibold text-[#92fa87]">Fecha y hora</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faCalendar" class="text-[#00d58b]"></fa-icon>
-          <input
-            type="datetime-local"
-            formControlName="starts_at"
-            class="w-full p-3 rounded-lg bg-[#001a1f] border border-[#00d58b]/30 focus:ring-2 focus:ring-[#00d58b] focus:outline-none"
-          />
-        </div>
-      </div>
+          <label class="neo-field">
+            <span>Fecha y hora</span>
+            <div class="neo-field__control">
+              <fa-icon [icon]="faCalendar" class="neo-field__icon"></fa-icon>
+              <input type="datetime-local" formControlName="starts_at" />
+            </div>
+          </label>
 
-      <div>
-        <label class="block mb-1 font-semibold text-[#92fa87]">Capacidad</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faUsers" class="text-[#00d58b]"></fa-icon>
-          <input
-            type="number"
-            formControlName="capacity"
-            class="w-full p-3 rounded-lg bg-[#001a1f] border border-[#00d58b]/30 focus:ring-2 focus:ring-[#00d58b] focus:outline-none"
-          />
-        </div>
-      </div>
-    </div>
+          <label class="neo-field">
+            <span>Capacidad</span>
+            <div class="neo-field__control">
+              <fa-icon [icon]="faUsers" class="neo-field__icon"></fa-icon>
+              <input type="number" formControlName="capacity" min="0" />
+            </div>
+          </label>
 
-    <!-- Precio / Imagen 
-    <div class="grid sm:grid-cols-2 gap-4">
-      <div>
-        <label class="block mb-1 font-semibold text-[#92fa87]">Precio</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faMoneyBillWave" class="text-[#00d58b]"></fa-icon>
-          <input
-            type="number"
-            formControlName="price"
-            class="w-full p-3 rounded-lg bg-[#001a1f] border border-[#00d58b]/30 focus:ring-2 focus:ring-[#00d58b] focus:outline-none"
-          />
-        </div>
-      </div>
+          <label class="neo-field">
+            <span>Precio</span>
+            <div class="neo-field__control">
+              <fa-icon [icon]="faMoneyBillWave" class="neo-field__icon"></fa-icon>
+              <input type="number" formControlName="price" min="0" placeholder="0" />
+            </div>
+          </label>
 
-      <div>
-        <label class="block mb-1 font-semibold text-[#92fa87]">Imagen</label>
-        <div class="flex items-center gap-2">
-          <fa-icon [icon]="faImage" class="text-[#00d58b]"></fa-icon>
-          <input
-            type="file"
-            (change)="onFileChange($event)"
-            class="block w-full text-sm text-gray-400 file:mr-4 file:py-2 file:px-3 file:rounded-md file:border-0 file:bg-[#00d58b] file:text-black hover:file:bg-[#92fa87] transition"
-          />
-        </div>
-      </div>
-    </div>
-
-    <!-- Preview 
-    <img
-      *ngIf="imagePreview"
-      [src]="imagePreview"
-      class="w-full rounded-lg mt-2 h-48 object-cover"
-    />
-
-    <!-- Botón submit 
-    <button
-      type="submit"
-      class="w-full py-3 bg-[#00d58b] hover:bg-[#92fa87] text-black font-semibold rounded-xl transition shadow-md disabled:opacity-50"
-      [disabled]="uploading"
-    >
-      Crear Evento
-    </button>
-
-    <!-- Error 
-    <p *ngIf="errorMessage" class="text-red-500 mt-2">{{ errorMessage }}</p>
-  </form>
-</div> -->
-
-<section class="min-h-screen text-gray-300 bg-[#0a0a0a] body-font">
-  <div class="container px-5 py-12 mx-auto">
-    <div class="flex flex-col items-center text-center mb-10">
-      <h1 class="text-4xl font-extrabold text-[#00d58b] drop-shadow-lg">Nuevo evento</h1>
-    </div>
-
-    <!-- Card estilo login -->
-    <div
-      class="max-w-3xl mx-auto border-2 border-[#00d58b] bg-black p-8 rounded-3xl shadow-[0_0_30px_#00d58b80] transform transition-all duration-300"
-    >
-      <form [formGroup]="eventForm" (ngSubmit)="onSubmit()" class="space-y-6">
-        <!-- Grid 1 / 2 cols -->
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div class="md:col-span-2">
-            <label class="text-gray-400 mb-1 block">Título</label>
-            <input
-              placeholder="Ingrese el título del evento..."
-              formControlName="title"
-              class="w-full p-3 rounded-xl bg-[#0f0f0f] text-white placeholder-gray-500 border border-[#00d58b]/30 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-            />
-          </div>
-
-          <div class="md:col-span-2">
-            <label class="text-gray-400 mb-1 block">Descripción</label>
-            <textarea
-              rows="3"
-              placeholder="Ingrese una breve descripción del evento..."
-              formControlName="description"
-              class="w-full p-3 rounded-xl bg-[#0f0f0f] text-white placeholder-gray-500 border border-[#00d58b]/30 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-            ></textarea>
-          </div>
-
-          <div>
-            <label class="text-gray-400 mb-1 block">Fecha y hora</label>
-            <input
-              type="datetime-local"
-              formControlName="starts_at"
-              class="w-full p-3 rounded-xl bg-[#0f0f0f] text-white border border-[#00d58b]/30 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-            />
-          </div>
-
-          <div>
-            <label class="text-gray-400 mb-1 block">Capacidad</label>
-            <input
-              type="number"
-              formControlName="capacity"
-              class="w-full p-3 rounded-xl bg-[#0f0f0f] text-white border border-[#00d58b]/30 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-            />
-          </div>
-
-          <div>
-            <label class="text-gray-400 mb-1 block">Precio</label>
-            <input
-              type="number"
-              placeholder="$99999"
-              formControlName="price"
-              class="w-full p-3 rounded-xl bg-[#0f0f0f] text-white placeholder-gray-500 border border-[#00d58b]/30 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-            />
-          </div>
-
-          <div>
-            <label class="text-gray-400 mb-1 block">Imagen</label>
-            <input
-              type="file"
-              (change)="onFileChange($event)"
-              class="block w-full text-sm text-gray-300 file:mr-4 file:py-2 file:px-3 file:rounded-md file:border-0 file:bg-[#00d58b] file:text-black hover:file:bg-[#92fa87] transition rounded-xl bg-[#0f0f0f] border border-[#00d58b]/30"
-            />
+          <div class="neo-field">
+            <span>Imagen destacada</span>
+            <label class="neo-upload create-event-upload">
+              <input type="file" accept="image/*" (change)="onFileChange($event)" />
+              <fa-icon [icon]="faImage"></fa-icon>
+              Subir imagen
+            </label>
+            <small>Formatos JPG o PNG. Tamaño recomendado 1200x600px.</small>
           </div>
         </div>
 
-        <!-- Submit -->
-        <div>
-          <button
-            type="submit"
-            class="w-full bg-[#00d58b] py-3 rounded-full font-semibold text-black flex justify-center items-center gap-2 hover:opacity-90 transition"
-          >
-            Crear Evento
-          </button>
-          <p *ngIf="errorMessage" class="text-red-500 mt-2 text-sm text-center">
-            {{ errorMessage }}
-          </p>
+        <div class="create-event-preview" *ngIf="imagePreview">
+          <img [src]="imagePreview" alt="Vista previa" />
         </div>
+
+        <div *ngIf="errorMessage" class="neo-feedback neo-feedback--error">
+          {{ errorMessage }}
+        </div>
+
+        <button type="submit" class="neo-button neo-button--primary" [disabled]="uploading || eventForm.invalid">
+          <ng-container *ngIf="uploading; else buttonLabel">
+            <span class="neo-loader"></span>
+            Guardando...
+          </ng-container>
+          <ng-template #buttonLabel>Publicar evento</ng-template>
+        </button>
       </form>
-    </div>
+    </article>
   </div>
 </section>
 

--- a/frontend/src/app/pages/create-event/create-event.scss
+++ b/frontend/src/app/pages/create-event/create-event.scss
@@ -1,71 +1,34 @@
-.event-form {
-  max-width: 32rem;
-  margin: 2rem auto;
-  padding: 2rem;
-  background: #111;
-  border-radius: 1.5rem;
-  box-shadow: 0 8px 20px rgba(0,0,0,0.6);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  color: #fff;
-
-  label {
-    font-weight: 600;
+.create-event-page {
+  .neo-card {
+    position: relative;
   }
 
-  input,
-  textarea {
-    background: #1a1a1a;
-    border: 1px solid #333;
-    border-radius: 0.75rem;
-    padding: 0.75rem 1rem;
-    color: #eee;
-    font-size: 0.95rem;
-    outline: none;
-    transition: all 0.2s;
+  .create-event-form {
+    gap: 1.5rem;
+  }
 
-    &:focus {
-      border-color: #6acaff;
-      box-shadow: 0 0 0 3px rgba(106, 202, 255, 0.3);
+  .create-event-upload {
+    justify-content: flex-start;
+  }
+
+  .create-event-preview {
+    border-radius: 1.1rem;
+    border: 1px solid rgba(56, 189, 248, 0.25);
+    overflow: hidden;
+    max-height: 260px;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
     }
   }
+}
 
-  textarea {
-    resize: none;
-  }
-
-  .preview-image {
-    width: 16rem;
-    height: 16rem;
-    object-fit: cover;
-    margin-top: 0.5rem;
-    border-radius: 1rem;
-    box-shadow: 0 4px 15px rgba(0,0,0,0.5);
-  }
-
-  button {
-    margin-top: 1rem;
-    padding: 0.75rem 1.5rem;
-    font-weight: 600;
-    border-radius: 1rem;
-    border: none;
-    cursor: pointer;
-    background: linear-gradient(to right, #06b6d4, #3b82f6);
-    color: #fff;
-    font-size: 1rem;
-    transition: all 0.3s ease;
-
-    &:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 18px rgba(0,0,0,0.5);
-      opacity: 0.9;
+@media (max-width: 768px) {
+  .create-event-page {
+    .neo-form__grid {
+      grid-template-columns: 1fr;
     }
-  }
-
-  .error-message {
-    color: #f87171;
-    font-weight: 500;
-    margin-top: 0.5rem;
   }
 }

--- a/frontend/src/app/pages/home/home.html
+++ b/frontend/src/app/pages/home/home.html
@@ -1,182 +1,91 @@
 <app-navbar></app-navbar>
 
-<section class="min-h-screen bg-[#0a0a0a] text-gray-200 px-6 sm:px-12 py-12">
-  <h2
-    class="text-4xl font-bold text-center mb-12 tracking-wide border-b-2 border-gray-800 p-6 bg-gradient-to-r from-emerald-400 to-emerald-900 bg-clip-text text-transparent"
-  >
-    Eventos Destacados
-  </h2>
-
-  <!-- filtros -->
-  <div class="flex justify-end gap-4 mb-10">
-    <!-- <select
-      class="bg-[#002e35] border border-[#00d58b]/40 text-gray-200 rounded-lg px-5 py-2"
-      (change)="onFilterDateChange($event)"
-    >
-      <option value="all">Todos los eventos</option>
-      <option value="today">Hoy</option>
-      <option value="week">Esta semana</option>
-      <option value="month">Este mes</option>
-      <option value="year">Este año</option>
-    </select> -->
-    <div class="relative">
-      <!-- sin overflow-hidden en este ni en ancestros -->
-      <button
-        (click)="open = !open"
-        class="w-64 rounded-lg px-5 py-2 bg-[#002e35] border border-[#00d58b]/40 text-gray-200 focus:outline-none focus:ring-2 focus:ring-[#00d58b]/50 flex justify-between"
-      >
-        <span>{{ selected?.label || 'Todos los eventos' }}</span>
-        <svg class="h-4 w-4 text-[#00d58b]" viewBox="0 0 20 20" fill="currentColor">
-          <path
-            d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.06 1.06l-4.24 4.24a.75.75 0 01-1.06 0L5.21 8.29a.75.75 0 01.02-1.08z"
-          />
-        </svg>
-      </button>
-
-      <ul
-        *ngIf="open"
-        class="absolute z-50 top-full left-0 w-full mt-2 rounded-lg bg-[#05262c] text-gray-100 border border-[#00d58b]/40 shadow-[0_0_20px_#00d58b33] max-h-60 overflow-auto"
-      >
-        <li
-          *ngFor="let opt of options"
-          (click)="select(opt)"
-          class="px-4 py-2 cursor-pointer hover:bg-[#08363f]"
-        >
-          {{ opt.label }}
-        </li>
-      </ul>
+<section class="neo-page neo-page--with-nav home-page">
+  <div class="neo-wrapper">
+    <div class="neo-hero home-hero">
+      <span class="neo-card__eyebrow">Descubrí experiencias en vivo</span>
+      <h1 class="neo-hero__title">Eventos destacados</h1>
+      <p class="neo-hero__subtitle">
+        Explorá la agenda actualizada y encontrá tu próximo show, conferencia o actividad favorita.
+      </p>
     </div>
-  </div>
 
-  <!-- Grid con animación -->
-  <div
-    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-10 transition-opacity duration-500"
-    [class.opacity-0]="!animated"
-    [class.opacity-100]="animated"
-  >
-    <!-- <div
-      *ngFor="let event of paginatedEvents"
-      class="group bg-gradient-to-b from-[#002e35] to-[#0f0f0f] border border-[#00d58b]/20 rounded-2xl overflow-hidden shadow-md hover:shadow-[#00d58b]/30 transition-all duration-500 hover:-translate-y-2 cursor-pointer animate-fadeIn"
-      [routerLink]="['/event', event.id]"
-    >
-      <div class="relative overflow-hidden h-56">
-        <img
-          *ngIf="event.image_path"
-          [src]="event.image_path"
-          [alt]="event.title"
-          class="w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-700"
-        />
-        <div
-          class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent"
-        ></div>
+    <div class="home-controls">
+      <div class="neo-select" [class.neo-select--open]="open">
+        <button class="neo-select__button" type="button" (click)="open = !open">
+          <span>{{ selected.label || 'Todos los eventos' }}</span>
+          <fa-icon [icon]="faChevronDown"></fa-icon>
+        </button>
+        <ul *ngIf="open" class="neo-select__list">
+          <li *ngFor="let opt of options" (click)="select(opt)" class="neo-select__option">
+            {{ opt.label }}
+          </li>
+        </ul>
       </div>
 
-      <div class="p-5">
-        <h3
-          class="text-lg font-semibold text-[#ffffa3] group-hover:text-[#92fa87] transition truncate"
-        >
-          {{ event.title }}
-        </h3>
+      <button type="button" class="neo-button neo-button--ghost home-reset" (click)="resetFilters()">
+        <fa-icon [icon]="faRetweet"></fa-icon>
+        Limpiar filtros
+      </button>
+    </div>
 
-        <p class="text-sm text-gray-400 line-clamp-2 mt-2" *ngIf="event.description">
-          {{ event.description }}
-        </p>
-
-        <div
-          class="flex justify-between items-center text-sm pt-4 mt-4 border-t border-[#00d58b]/20"
-        >
-          <span class="text-gray-400 flex items-center gap-1">
-            <fa-icon [icon]="faCalendar" class="text-[#00d58b] text-[18px]"></fa-icon>
-            {{ event.starts_at | date : 'dd/MM/yyyy' }}
-          </span>
-
-          <span
-            class="text-[#00d58b] font-semibold group-hover:text-[#92fa87] transition flex items-center gap-1"
-          >
-            Ver más
-            <fa-icon [icon]="faArrowRight"></fa-icon>
-          </span>
+    <div class="neo-grid home-grid" [class.home-grid--hidden]="!animated">
+      <article class="neo-card home-card" *ngFor="let event of paginatedEvents">
+        <div class="home-card__media" *ngIf="event.image_path; else placeholder">
+          <img [src]="event.image_path" [alt]="event.title" />
         </div>
-      </div>
-    </div> -->
-    <div
-      class="rounded-2xl transition-all duration-300 hover:bg-gradient-to-b from-[#002e35] to-[#0f0f0f] hover:scale-105 hover:border-[#00d58b] hover:shadow-[0_0_1px_#00d58b,0_0_10px_#00d58b]"
-      *ngFor="let event of paginatedEvents"
-    >
-      <div class="h-full rounded-2xl overflow-hidden">
-        <img
-          class="lg:h-48 md:h-36 w-full object-cover object-center"
-          *ngIf="event.image_path"
-          [src]="event.image_path"
-          [alt]="event.title"
-        />
-        <div class="p-6">
-          <h1 class="title-font text-3xl font-medium text-[#00d58b] mb-3">{{ event.title }}</h1>
-          <p class="leading-relaxed mb-3 text-lg">
+        <ng-template #placeholder>
+          <div class="home-card__media home-card__media--placeholder">
+            <span>{{ event.title.charAt(0) }}</span>
+          </div>
+        </ng-template>
+
+        <div class="home-card__body">
+          <h2 class="home-card__title">{{ event.title }}</h2>
+          <p class="home-card__description" *ngIf="event.description">
             {{ event.description }}
           </p>
-          <div class="flex items-center flex-wrap border-t-2 border-gray-800 pt-4 mt-2">
-            <a
-              [routerLink]="['/event', event.id]"
-              class="text-[#00d58b] inline-flex items-center md:mb-2 lg:mb-0 cursor-pointer text-lg"
-            >
-              Saber más
-              <svg
-                class="w-4 h-4 ml-2"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="2"
-                fill="none"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              >
-                <path d="M5 12h14"></path>
-                <path d="M12 5l7 7-7 7"></path>
-              </svg>
-            </a>
-            <span
-              class="text-gray-500 mr-3 inline-flex items-center lg:ml-auto md:ml-0 ml-auto leading-none text-lg pr-3 py-1 border-r-2 border-gray-800"
-            >
-              <fa-icon class="pr-1 text-[#00d58b]" [icon]="faTicket"></fa-icon>
 
-              {{ event.capacity }}
+          <div class="home-card__meta">
+            <span>
+              <fa-icon [icon]="faCalendar"></fa-icon>
+              {{ event.starts_at | date: 'dd/MM/yyyy HH:mm' }}
             </span>
-            <span class="text-gray-500 inline-flex items-center leading-none text-lg">
-              <fa-icon [icon]="faCalendar" class="text-[#00d58b] mr-2"></fa-icon>
-              {{ event.starts_at | date : 'dd/MM/yyyy' }}
+            <span>
+              <fa-icon [icon]="faTicket"></fa-icon>
+              {{ event.capacity }} lugares
             </span>
           </div>
+
+          <a class="home-card__cta" [routerLink]="['/event', event.id]">
+            Ver evento
+            <fa-icon [icon]="faArrowRight"></fa-icon>
+          </a>
         </div>
+      </article>
+    </div>
+
+    <div class="home-empty" *ngIf="filteredEvents.length === 0">
+      <div class="neo-feedback neo-feedback--info">
+        No encontramos eventos para los filtros seleccionados. Probá cambiarlos para ver más opciones.
       </div>
     </div>
-  </div>
 
-  <!-- Paginación -->
-  <div class="flex justify-center gap-4 mt-12" *ngIf="filteredEvents.length > pageSize">
-    <button
-      class="px-5 py-2 rounded-lg bg-[#002e35] border border-[#00d58b]/40 hover:bg-[#00414a] transition"
-      (click)="prevPage()"
-      [disabled]="currentPage === 1"
-    >
-      Anterior
-    </button>
-
-    <span class="text-gray-300 font-semibold my-auto">
-      Página {{ currentPage }} de {{ totalPages() }}
-    </span>
-
-    <button
-      class="px-5 py-2 rounded-lg bg-[#002e35] border border-[#00d58b]/40 hover:bg-[#00414a] transition"
-      (click)="nextPage()"
-      [disabled]="currentPage * pageSize >= filteredEvents.length"
-    >
-      Siguiente
-    </button>
-  </div>
-
-  <!-- Si no hay eventos -->
-  <div *ngIf="filteredEvents.length === 0" class="text-center mt-20 text-gray-400 text-lg">
-    <p>No se encontraron eventos 😔</p>
+    <div class="home-pagination" *ngIf="filteredEvents.length > pageSize">
+      <button type="button" class="neo-button neo-button--ghost" (click)="prevPage()" [disabled]="currentPage === 1">
+        Anterior
+      </button>
+      <span class="neo-text--muted">Página {{ currentPage }} de {{ totalPages() }}</span>
+      <button
+        type="button"
+        class="neo-button neo-button--ghost"
+        (click)="nextPage()"
+        [disabled]="currentPage * pageSize >= filteredEvents.length"
+      >
+        Siguiente
+      </button>
+    </div>
   </div>
 </section>
+
 <app-footer></app-footer>

--- a/frontend/src/app/pages/home/home.scss
+++ b/frontend/src/app/pages/home/home.scss
@@ -1,35 +1,132 @@
-.home-section {
-  font-family: 'SF Pro Display', 'Inter', system-ui, sans-serif;
+.home-page {
+  .home-hero {
+    gap: 0.75rem;
+  }
 
-  .event-card {
-    backdrop-filter: blur(8px);
-    background: linear-gradient(145deg, #111, #0d0d0e);
-    border: 1px solid rgba(255, 255, 255, 0.05);
+  .home-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .home-reset {
+    min-width: 180px;
+  }
+
+  .home-grid {
+    transition: opacity 0.35s ease, transform 0.35s ease;
+    &--hidden {
+      opacity: 0;
+      transform: translateY(12px);
+      pointer-events: none;
+    }
+  }
+
+  .home-card {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding: 1.5rem;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
 
     &:hover {
-      border-color: rgba(0, 198, 255, 0.3);
+      transform: translateY(-6px);
+      box-shadow: 0 28px 45px rgba(20, 184, 166, 0.18);
     }
+  }
+
+  .home-card__media {
+    width: 100%;
+    height: 200px;
+    border-radius: 1.1rem;
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     img {
-      transition: transform 0.5s ease;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      transition: transform 0.45s ease;
     }
+  }
 
-    h3 {
-      letter-spacing: 0.3px;
+  .home-card:hover .home-card__media img {
+    transform: scale(1.05);
+  }
+
+  .home-card__media--placeholder {
+    font-size: 3rem;
+    font-weight: 700;
+    color: rgba(94, 234, 212, 0.85);
+    letter-spacing: 0.15em;
+  }
+
+  .home-card__body {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .home-card__title {
+    margin: 0;
+    font-size: 1.4rem;
+    color: #f8fafc;
+  }
+
+  .home-card__description {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.82);
+    line-height: 1.6;
+  }
+
+  .home-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: space-between;
+    color: rgba(148, 163, 184, 0.9);
+
+    span {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
     }
+  }
+
+  .home-card__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: #5eead4;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: #34d399;
+    }
+  }
+
+  .home-empty {
+    display: flex;
+    justify-content: center;
+  }
+
+  .home-pagination {
+    display: flex;
+    justify-content: center;
+    gap: 1.25rem;
+    align-items: center;
   }
 }
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(12px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 
-.animate-fadeIn {
-  animation: fadeIn 0.6s ease-in-out;
+@media (max-width: 768px) {
+  .home-page {
+    .home-card__media {
+      height: 180px;
+    }
+  }
 }

--- a/frontend/src/app/pages/home/home.ts
+++ b/frontend/src/app/pages/home/home.ts
@@ -6,7 +6,7 @@ import { RouterLink } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { SearchService } from '../../services/search.service';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faCalendar, faArrowRight, faTicket, faRetweet } from '@fortawesome/free-solid-svg-icons';
+import { faCalendar, faArrowRight, faTicket, faRetweet, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { FooterComponent } from '../footer/footer';
 
 interface Event {
@@ -68,6 +68,7 @@ export class Home implements OnInit, OnDestroy {
   faArrowRight = faArrowRight;
   faTicket = faTicket;
   faRetweet = faRetweet;
+  faChevronDown = faChevronDown;
 
   constructor(private http: HttpClient, private searchService: SearchService) {}
 
@@ -104,6 +105,8 @@ export class Home implements OnInit, OnDestroy {
   resetFilters() {
     this.filters = { term: '', date: 'all' };
     this.currentPage = 1;
+    this.selected = this.options[0];
+    this.open = false;
     this.applyFilters(true);
     this.searchService.updateSearchTerm('');
   }

--- a/frontend/src/app/pages/navbar/navbar.html
+++ b/frontend/src/app/pages/navbar/navbar.html
@@ -59,6 +59,25 @@
       </div>
     </nav>
     <button
+      *ngIf="isLoggedIn"
+      (click)="goToProfile()"
+      class="inline-flex items-center bg-gray-800 border-0 py-1 px-3 focus:outline-none hover:text-black hover:bg-[#00d58b] rounded text-base mt-4 md:mt-0 mr-3"
+    >
+      <span class="relative flex items-center justify-center w-8 h-8 mr-2">
+        <img
+          *ngIf="avatarUrl; else defaultAvatar"
+          [src]="avatarUrl"
+          alt="Avatar"
+          class="w-8 h-8 rounded-full border border-[#00d58b]/60 object-cover"
+        />
+        <ng-template #defaultAvatar>
+          <fa-icon [icon]="faCircleUser" class="text-xl text-[#00d58b]"></fa-icon>
+        </ng-template>
+      </span>
+      <span class="hidden sm:inline">{{ userName || 'Mi perfil' }}</span>
+      <fa-icon [icon]="faGear" class="ml-2 text-sm"></fa-icon>
+    </button>
+    <button
       *ngIf="isLoggedIn && !isVerified && userRole != 'admin'"
       (click)="requestVerification()"
       [disabled]="loadingVerify"

--- a/frontend/src/app/pages/navbar/navbar.ts
+++ b/frontend/src/app/pages/navbar/navbar.ts
@@ -13,6 +13,8 @@ import {
   faRightFromBracket,
   faRightToBracket,
   faExclamation,
+  faCircleUser,
+  faGear,
 } from '@fortawesome/free-solid-svg-icons';
 @Component({
   selector: 'app-navbar',
@@ -29,6 +31,8 @@ export class NavbarComponent implements OnInit {
   isVerified: boolean = false;
   verifyMessage: string = '';
   loadingVerify: boolean = false;
+  userName: string = '';
+  avatarUrl: string | null = null;
 
   constructor(
     private router: Router,
@@ -60,6 +64,8 @@ export class NavbarComponent implements OnInit {
           if (user && user.email) {
             localStorage.setItem('email', user.email);
           }
+          this.userName = user?.name ?? '';
+          this.avatarUrl = user?.avatar_url ?? null;
         },
         error: () => this.logout(false),
       });
@@ -72,6 +78,8 @@ export class NavbarComponent implements OnInit {
   faRightFromBracket = faRightFromBracket;
   faRightToBracket = faRightToBracket;
   faExclamation = faExclamation;
+  faCircleUser = faCircleUser;
+  faGear = faGear;
 
   toggleMenu(): void {
     this.isMenuOpen = !this.isMenuOpen;
@@ -98,6 +106,8 @@ export class NavbarComponent implements OnInit {
     this.isLoggedIn = false;
     this.userRole = '';
     this.isVerified = false;
+    this.userName = '';
+    this.avatarUrl = null;
     this.cdr.detectChanges();
     if (navigate) this.router.navigate(['/login']);
   }
@@ -122,5 +132,9 @@ export class NavbarComponent implements OnInit {
         this.loadingVerify = false;
       },
     });
+  }
+
+  goToProfile(): void {
+    this.navigate('/profile');
   }
 }

--- a/frontend/src/app/pages/ticket-scanner/ticket-scanner.html
+++ b/frontend/src/app/pages/ticket-scanner/ticket-scanner.html
@@ -1,118 +1,103 @@
 <app-navbar></app-navbar>
 
-<div class="min-h-screen bg-[#0a0a0a] text-gray-200 flex flex-col items-center px-6 py-12">
-  <!-- Card estilo login -->
-  <div
-    class="w-full max-w-3xl text-center border-2 border-[#00d58b] bg-black p-10 rounded-3xl shadow-[0_0_30px_#00d58b80] backdrop-blur-md transform transition-all duration-300"
-  >
-    <h2 class="text-3xl font-extrabold mb-6 text-[#00d58b] tracking-wide">Validar Tickets</h2>
+<section class="neo-page neo-page--with-nav scanner-page">
+  <div class="neo-wrapper neo-wrapper--wide">
+    <article class="neo-card neo-card--accent scanner-card">
+      <header class="neo-card__header">
+        <span class="neo-card__eyebrow">Controlá el acceso en tiempo real</span>
+        <h1 class="neo-card__title">Validar tickets</h1>
+        <p class="neo-card__subtitle">
+          Elegí un evento, escaneá el código QR o subí una imagen y asegurate de que cada ticket sea auténtico.
+        </p>
+      </header>
 
-    <!-- Selección de evento -->
-    <div class="mb-8 text-left">
-      <label class="block mb-2 font-semibold text-sm text-gray-400">Selecciona un evento:</label>
-      <select
-        [(ngModel)]="selectedEventId"
-        (change)="selectEvent()"
-        class="w-full p-3 rounded-xl bg-[#0f0f0f] text-gray-100 placeholder-gray-500 border border-[#00d58b]/30 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-      >
-        <option [value]="null">-Selecciona un evento-</option>
-        <option *ngFor="let e of events" [value]="e.id">{{ e.title }}</option>
-      </select>
-    </div>
+      <div class="scanner-actions">
+        <label class="neo-field">
+          <span>Seleccioná un evento</span>
+          <div class="neo-field__control">
+            <select [(ngModel)]="selectedEventId" (change)="selectEvent()">
+              <option [ngValue]="null">Elegí un evento</option>
+              <option *ngFor="let e of events" [ngValue]="e.id">{{ e.title }}</option>
+            </select>
+          </div>
+        </label>
 
-    <!-- Toggle cámara / archivo -->
-    <button
-      (click)="useFileInput = !useFileInput"
-      class="mb-6 px-5 py-2.5 rounded-full font-semibold text-black bg-[#00d58b] hover:opacity-90 shadow-[0_0_14px_#00d58b80] transition-all"
-    >
-      {{ useFileInput ? 'Usar cámara' : 'Subir QR desde archivo' }}
-    </button>
-
-    <!-- Scanner de cámara -->
-    <div
-      *ngIf="!useFileInput && selectedEventId"
-      class="rounded-2xl overflow-hidden mb-6 border-2 border-[#00d58b]/40 shadow-[0_0_18px_#00d58b40]"
-    >
-      <zxing-scanner
-        (scanSuccess)="onCodeResult($event)"
-        [formats]="formats"
-        class="w-full h-72"
-      ></zxing-scanner>
-    </div>
-
-    <!-- Input de archivo -->
-    <div *ngIf="useFileInput && selectedEventId" class="mb-8">
-      <input
-        type="file"
-        (change)="onFileSelected($event)"
-        accept="image/*"
-        class="w-full p-3 rounded-xl bg-[#0f0f0f] text-gray-300 cursor-pointer border border-[#00d58b]/30 hover:border-[#00d58b]/60 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-[#00d58b] focus:shadow-[0_0_12px_#00d58b66] transition"
-      />
-    </div>
-
-    <!-- Resultado QR -->
-    <div *ngIf="qrResult || message" class="mb-6 space-y-2">
-      <p *ngIf="qrResult" class="text-gray-300 flex items-center justify-center gap-2 text-sm">
-        <fa-icon [icon]="faQrcode" class="text-[#00d58b]"></fa-icon>
-        <span class="break-all">{{ qrResult }}</span>
-      </p>
-      <p
-        *ngIf="message"
-        class="text-sm font-semibold flex items-center justify-center gap-2"
-        [ngClass]="{
-          'text-green-400': message.includes('válido') || message.includes('exitosamente'),
-          'text-red-400': message.includes('inválido') || message.includes('usado')
-        }"
-      >
-        <fa-icon [icon]="faCheck"></fa-icon> {{ message }}
-      </p>
-    </div>
-
-    <!-- Tabla de tickets -->
-    <div *ngIf="orders.length" class="mt-8 text-left">
-      <h3 class="text-xl text-[#00d58b] font-semibold mb-4 text-center">Tickets del evento</h3>
-
-      <div
-        class="overflow-x-auto rounded-2xl border border-[#00d58b]/15 shadow-[0_0_10px_#00d58b1f]"
-      >
-        <table class="w-full text-sm border-collapse">
-          <thead
-            class="bg-[#0f0f0f] border-b border-[#00d58b]/25 text-gray-400 uppercase text-xs tracking-wider"
-          >
-            <tr>
-              <th class="px-4 py-3 text-left">ID</th>
-              <th class="px-4 py-3 text-left">
-                <fa-icon [icon]="faUser" class="text-[#00d58b]"></fa-icon> Usuario
-              </th>
-              <th class="px-4 py-3 text-left">
-                <fa-icon [icon]="faTicketAlt" class="text-[#00d58b]"></fa-icon> QR
-              </th>
-              <th class="px-4 py-3 text-left">Estado</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor="let o of orders" class="hover:bg-[#0c0c0c] transition">
-              <td class="px-4 py-3 border-t border-[#1a1a1a]">{{ o.id }}</td>
-              <td class="px-4 py-3 border-t border-[#1a1a1a]">
-                <div class="font-semibold text-gray-100">{{ o.user?.name }}</div>
-                <div class="text-xs text-gray-400">{{ o.user?.email }}</div>
-                <div class="text-[10px] text-gray-500">ID: {{ o.user?.id }}</div>
-              </td>
-              <td class="px-4 py-3 border-t border-[#1a1a1a] break-all text-xs text-gray-400">
-                {{ o.qr_code }}
-              </td>
-              <td
-                class="px-4 py-3 border-t border-[#1a1a1a] font-semibold"
-                [ngClass]="{ 'text-green-400': !o.used, 'text-red-400': o.used }"
-              >
-                {{ o.used ? 'Usado' : 'Disponible' }}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        <button type="button" class="neo-button neo-button--ghost" (click)="useFileInput = !useFileInput" [disabled]="!selectedEventId">
+          <fa-icon [icon]="faQrcode"></fa-icon>
+          {{ useFileInput ? 'Usar cámara' : 'Subir QR desde archivo' }}
+        </button>
       </div>
-    </div>
+
+      <div class="scanner-viewport" *ngIf="selectedEventId">
+        <div *ngIf="!useFileInput" class="scanner-camera">
+          <zxing-scanner (scanSuccess)="onCodeResult($event)" [formats]="formats"></zxing-scanner>
+        </div>
+
+        <div *ngIf="useFileInput" class="scanner-upload">
+          <label class="neo-upload">
+            <input type="file" accept="image/*" (change)="onFileSelected($event)" />
+            <fa-icon [icon]="faImage"></fa-icon>
+            Seleccionar imagen
+          </label>
+        </div>
+      </div>
+
+      <div class="scanner-result" *ngIf="qrResult || message">
+        <div class="neo-feedback neo-feedback--info" *ngIf="qrResult">
+          <fa-icon [icon]="faQrcode"></fa-icon>
+          <span class="scanner-result__code">{{ qrResult }}</span>
+        </div>
+        <div
+          *ngIf="message"
+          class="neo-feedback"
+          [ngClass]="{
+            'neo-feedback--success': message.includes('válido') || message.includes('exitosamente'),
+            'neo-feedback--error': message.includes('inválido') || message.includes('usado')
+          }"
+        >
+          <fa-icon [icon]="faCheck"></fa-icon>
+          {{ message }}
+        </div>
+      </div>
+
+      <div *ngIf="orders.length" class="scanner-table">
+        <h2 class="neo-section-title">
+          <fa-icon [icon]="faTicketAlt"></fa-icon>
+          Tickets escaneados
+        </h2>
+        <div class="neo-table-container">
+          <table class="neo-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Usuario</th>
+                <th>QR</th>
+                <th>Estado</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let o of orders">
+                <td>{{ o.id }}</td>
+                <td>
+                  <div class="scanner-user">
+                    <strong>{{ o.user?.name }}</strong>
+                    <span>{{ o.user?.email }}</span>
+                    <small>ID: {{ o.user?.id }}</small>
+                  </div>
+                </td>
+                <td class="scanner-code">{{ o.qr_code }}</td>
+                <td>
+                  <span class="neo-badge" [ngClass]="o.used ? 'neo-badge--warning' : 'neo-badge--success'">
+                    {{ o.used ? 'Usado' : 'Disponible' }}
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </article>
   </div>
-</div>
+</section>
 
 <app-footer></app-footer>

--- a/frontend/src/app/pages/ticket-scanner/ticket-scanner.scss
+++ b/frontend/src/app/pages/ticket-scanner/ticket-scanner.scss
@@ -1,15 +1,86 @@
-@keyframes fadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(10px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
+.scanner-page {
+  .scanner-card {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .scanner-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    align-items: center;
+  }
+
+  .scanner-viewport {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .scanner-camera {
+    border-radius: 1.1rem;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    overflow: hidden;
+    min-height: 260px;
+
+    zxing-scanner {
+      width: 100%;
+      min-height: 260px;
+      display: block;
     }
   }
-  
-  .animate-fadeIn {
-    animation: fadeIn 0.6s ease-out;
+
+  .scanner-upload {
+    display: flex;
+    justify-content: flex-start;
   }
-  
+
+  .scanner-result {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .scanner-result__code {
+    word-break: break-all;
+  }
+
+  .scanner-table {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .scanner-user {
+    display: grid;
+    gap: 0.25rem;
+    color: rgba(226, 232, 240, 0.82);
+
+    span {
+      font-size: 0.85rem;
+      color: rgba(148, 163, 184, 0.9);
+    }
+
+    small {
+      font-size: 0.7rem;
+      color: rgba(148, 163, 184, 0.65);
+    }
+  }
+
+  .scanner-code {
+    word-break: break-all;
+    font-size: 0.8rem;
+    color: rgba(148, 163, 184, 0.85);
+  }
+}
+
+@media (max-width: 768px) {
+  .scanner-page {
+    .scanner-actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .scanner-card {
+      padding: 1.5rem;
+    }
+  }
+}

--- a/frontend/src/app/pages/ticket-scanner/ticket-scanner.ts
+++ b/frontend/src/app/pages/ticket-scanner/ticket-scanner.ts
@@ -6,7 +6,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { ZXingScannerModule } from '@zxing/ngx-scanner';
 import { BrowserMultiFormatReader, BarcodeFormat } from '@zxing/library';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faHome, faQrcode, faUser, faTicketAlt, faCheck } from '@fortawesome/free-solid-svg-icons';
+import { faQrcode, faTicketAlt, faCheck, faImage } from '@fortawesome/free-solid-svg-icons';
 import { NavbarComponent } from '../navbar/navbar';
 import { FooterComponent } from '../footer/footer';
 
@@ -55,11 +55,10 @@ export class TicketScanner implements OnInit {
   useFileInput = false;
 
   reader = new BrowserMultiFormatReader();
-  faHome = faHome;
   faQrcode = faQrcode;
-  faUser = faUser;
   faTicketAlt = faTicketAlt;
   faCheck = faCheck;
+  faImage = faImage;
 
   constructor(private http: HttpClient) {}
 

--- a/frontend/src/app/pages/user-profile/user-profile.html
+++ b/frontend/src/app/pages/user-profile/user-profile.html
@@ -1,0 +1,151 @@
+<app-navbar></app-navbar>
+<section class="profile-page">
+  <div class="wrapper">
+    <header class="profile-header">
+      <div class="avatar">
+        <img *ngIf="avatarPreview; else defaultAvatar" [src]="avatarPreview" alt="Avatar" />
+        <ng-template #defaultAvatar>
+          <div class="placeholder">{{ user?.name?.charAt(0) || 'U' }}</div>
+        </ng-template>
+      </div>
+      <div class="info">
+        <h1>{{ user?.name || 'Mi perfil' }}</h1>
+        <p class="email">{{ user?.email }}</p>
+        <p class="meta">
+          Miembro desde {{ user?.created_at | date: 'longDate' }} ·
+          <span [class.text-green]="user?.is_verified" [class.text-warning]="!user?.is_verified">
+            {{ user?.is_verified ? 'Cuenta verificada' : 'Cuenta pendiente de verificación' }}
+          </span>
+        </p>
+      </div>
+    </header>
+
+    <div class="grid">
+      <section class="card">
+        <div class="card-header">
+          <h2><fa-icon [icon]="faFloppyDisk"></fa-icon> Información personal</h2>
+          <button type="button" class="ghost" (click)="resetProfile()">
+            <fa-icon [icon]="faRotateLeft"></fa-icon>
+            Revertir cambios
+          </button>
+        </div>
+
+        <form [formGroup]="profileForm" (ngSubmit)="onProfileSubmit()" class="form">
+          <div class="feedback" *ngIf="successMessage">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ successMessage }}
+          </div>
+          <div class="feedback error" *ngIf="errorMessage">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ errorMessage }}
+          </div>
+
+          <label class="field">
+            <span>Nombre</span>
+            <input type="text" formControlName="name" placeholder="Tu nombre completo" />
+            <small *ngIf="profileForm.get('name')?.invalid && profileForm.get('name')?.touched">
+              Ingresá un nombre válido (máx. 100 caracteres).
+            </small>
+          </label>
+
+          <label class="field">
+            <span>Correo electrónico</span>
+            <input type="email" formControlName="email" placeholder="tucorreo@ejemplo.com" />
+            <small *ngIf="profileForm.get('email')?.invalid && profileForm.get('email')?.touched">
+              Ingresá un correo válido.
+            </small>
+          </label>
+
+          <div class="field-group">
+            <label class="field">
+              <span>Teléfono</span>
+              <input type="text" formControlName="phone" placeholder="Opcional" />
+            </label>
+            <label class="field">
+              <span>Notificaciones por correo</span>
+              <label class="toggle">
+                <input type="checkbox" formControlName="email_notifications" />
+                <span class="slider"></span>
+              </label>
+            </label>
+          </div>
+
+          <label class="field">
+            <span>Biografía</span>
+            <textarea formControlName="bio" rows="4" placeholder="Contale al resto quién sos o qué haces"></textarea>
+          </label>
+
+          <div class="avatar-uploader">
+            <div class="preview" [class.placeholder]="!avatarPreview">
+              <img *ngIf="avatarPreview" [src]="avatarPreview" alt="Vista previa" />
+              <span *ngIf="!avatarPreview">
+                <fa-icon [icon]="faCamera"></fa-icon>
+                Subí una foto (máx. 2 MB)
+              </span>
+            </div>
+            <div class="actions">
+              <label class="upload">
+                <input type="file" accept="image/*" (change)="onAvatarChange($event)" />
+                <fa-icon [icon]="faCamera"></fa-icon>
+                Cambiar avatar
+              </label>
+              <button type="button" class="ghost danger" (click)="clearAvatar()" [disabled]="!avatarPreview">
+                <fa-icon [icon]="faTrash"></fa-icon>
+                Quitar avatar
+              </button>
+            </div>
+          </div>
+
+          <button class="primary" type="submit" [disabled]="loadingProfile">
+            <span *ngIf="loadingProfile" class="loader"></span>
+            <fa-icon *ngIf="!loadingProfile" [icon]="faFloppyDisk"></fa-icon>
+            Guardar cambios
+          </button>
+        </form>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2><fa-icon [icon]="faShieldHalved"></fa-icon> Seguridad</h2>
+        </div>
+        <form [formGroup]="passwordForm" (ngSubmit)="onPasswordSubmit()" class="form">
+          <div class="feedback success" *ngIf="passwordMessage">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ passwordMessage }}
+          </div>
+          <div class="feedback error" *ngIf="passwordError">
+            <fa-icon [icon]="faCircleInfo"></fa-icon>
+            {{ passwordError }}
+          </div>
+          <label class="field">
+            <span>Contraseña actual</span>
+            <input type="password" formControlName="current_password" placeholder="••••••••" />
+          </label>
+          <label class="field">
+            <span>Nueva contraseña</span>
+            <input type="password" formControlName="password" placeholder="Mínimo 8 caracteres" />
+          </label>
+          <label class="field">
+            <span>Confirmar contraseña</span>
+            <input type="password" formControlName="password_confirmation" placeholder="Repetí la nueva contraseña" />
+          </label>
+          <button class="primary" type="submit" [disabled]="loadingPassword">
+            <span *ngIf="loadingPassword" class="loader"></span>
+            <fa-icon *ngIf="!loadingPassword" [icon]="faLock"></fa-icon>
+            Actualizar contraseña
+          </button>
+        </form>
+
+        <div class="tips">
+          <h3><fa-icon [icon]="faBell"></fa-icon> Consejos rápidos</h3>
+          <ul>
+            <li>Usá una contraseña única y difícil de adivinar.</li>
+            <li>Activá las notificaciones para enterarte de tus compras y cambios importantes.</li>
+            <li>Mantené tus datos al día para recibir novedades relevantes.</li>
+          </ul>
+        </div>
+      </section>
+    </div>
+  </div>
+</section>
+<app-footer></app-footer>

--- a/frontend/src/app/pages/user-profile/user-profile.scss
+++ b/frontend/src/app/pages/user-profile/user-profile.scss
@@ -1,0 +1,394 @@
+.profile-page {
+  min-height: calc(100vh - 140px);
+  background: radial-gradient(circle at 20% 20%, rgba(0, 213, 139, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(34, 211, 238, 0.08), transparent 60%),
+    #0b1120;
+  padding: 3rem 1.5rem;
+  color: #e2e8f0;
+
+  .wrapper {
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+
+  .profile-header {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    background: linear-gradient(135deg, rgba(15, 118, 110, 0.6), rgba(7, 89, 133, 0.4));
+    box-shadow: 0 20px 45px rgba(2, 132, 199, 0.15);
+
+    .avatar {
+      width: 96px;
+      height: 96px;
+      border-radius: 50%;
+      overflow: hidden;
+      border: 3px solid rgba(16, 185, 129, 0.8);
+      background: rgba(15, 23, 42, 0.8);
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .placeholder {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        font-size: 2.5rem;
+        font-weight: 600;
+        color: rgba(16, 185, 129, 0.9);
+      }
+    }
+
+    .info {
+      h1 {
+        font-size: clamp(1.6rem, 2.5vw, 2.1rem);
+        margin: 0;
+        color: #f8fafc;
+        font-weight: 700;
+      }
+
+      .email {
+        margin: 0.25rem 0;
+        color: rgba(226, 232, 240, 0.8);
+      }
+
+      .meta {
+        font-size: 0.9rem;
+        color: rgba(148, 163, 184, 0.9);
+
+        .text-green {
+          color: #4ade80;
+        }
+
+        .text-warning {
+          color: #facc15;
+        }
+      }
+    }
+  }
+
+  .grid {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  }
+
+  .card {
+    background: rgba(15, 23, 42, 0.8);
+    border-radius: 1.25rem;
+    padding: 1.75rem;
+    border: 1px solid rgba(45, 212, 191, 0.08);
+    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
+    backdrop-filter: blur(8px);
+
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1.5rem;
+      gap: 1rem;
+
+      h2 {
+        font-size: 1.1rem;
+        font-weight: 600;
+        display: flex;
+        align-items: center;
+        gap: 0.65rem;
+        color: #f1f5f9;
+
+        fa-icon {
+          color: #2dd4bf;
+        }
+      }
+
+      .ghost {
+        background: rgba(14, 165, 233, 0.15);
+        color: #38bdf8;
+        border: 1px solid rgba(56, 189, 248, 0.35);
+        border-radius: 9999px;
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: all 0.25s ease;
+        cursor: pointer;
+
+        &:hover {
+          background: rgba(56, 189, 248, 0.25);
+          color: #0ea5e9;
+        }
+
+        &.danger {
+          border-color: rgba(248, 113, 113, 0.4);
+          color: #f87171;
+          background: rgba(239, 68, 68, 0.12);
+
+          &:hover {
+            background: rgba(239, 68, 68, 0.2);
+          }
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+      }
+    }
+
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 1.2rem;
+
+      .feedback {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.75rem 1rem;
+        border-radius: 0.85rem;
+        font-size: 0.9rem;
+        background: rgba(34, 197, 94, 0.12);
+        color: #86efac;
+
+        &.success {
+          background: rgba(22, 163, 74, 0.18);
+          color: #4ade80;
+        }
+
+        &.error {
+          background: rgba(248, 113, 113, 0.15);
+          color: #fca5a5;
+        }
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+
+        span {
+          font-size: 0.9rem;
+          color: rgba(148, 163, 184, 0.9);
+        }
+
+        input,
+        textarea {
+          background: rgba(15, 23, 42, 0.8);
+          border: 1px solid rgba(45, 212, 191, 0.15);
+          border-radius: 0.85rem;
+          padding: 0.75rem 1rem;
+          color: #e2e8f0;
+          transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+          &:focus {
+            border-color: rgba(16, 185, 129, 0.6);
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+          }
+        }
+
+        small {
+          color: #fda4af;
+          font-size: 0.75rem;
+        }
+      }
+
+      .field-group {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1rem;
+
+        @media (min-width: 640px) {
+          grid-template-columns: 1fr 1fr;
+        }
+
+        .toggle {
+          position: relative;
+          display: inline-flex;
+          align-items: center;
+          height: 42px;
+          padding: 0.5rem 0;
+
+          input {
+            display: none;
+          }
+
+          .slider {
+            width: 58px;
+            height: 30px;
+            background: rgba(148, 163, 184, 0.3);
+            border-radius: 999px;
+            position: relative;
+            transition: background 0.25s ease;
+
+            &::after {
+              content: '';
+              position: absolute;
+              width: 24px;
+              height: 24px;
+              border-radius: 999px;
+              background: #e2e8f0;
+              top: 3px;
+              left: 4px;
+              transition: transform 0.25s ease;
+            }
+          }
+
+          input:checked + .slider {
+            background: rgba(16, 185, 129, 0.45);
+
+            &::after {
+              transform: translateX(26px);
+              background: #10b981;
+            }
+          }
+        }
+      }
+
+      .avatar-uploader {
+        display: grid;
+        gap: 1rem;
+
+        .preview {
+          min-height: 150px;
+          border-radius: 1rem;
+          border: 1px dashed rgba(45, 212, 191, 0.35);
+          background: rgba(15, 23, 42, 0.6);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          overflow: hidden;
+
+          &.placeholder {
+            border-style: dashed;
+          }
+
+          img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+
+          span {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.35rem;
+            color: rgba(148, 163, 184, 0.9);
+
+            fa-icon {
+              font-size: 1.5rem;
+              color: #2dd4bf;
+            }
+          }
+        }
+
+        .actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.75rem;
+
+          .upload {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: rgba(34, 197, 94, 0.18);
+            color: #4ade80;
+            border: 1px solid rgba(34, 197, 94, 0.35);
+            border-radius: 999px;
+            padding: 0.5rem 1.25rem;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: all 0.2s ease;
+
+            input {
+              display: none;
+            }
+
+            &:hover {
+              background: rgba(34, 197, 94, 0.28);
+            }
+          }
+        }
+      }
+
+      .primary {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.65rem;
+        background: linear-gradient(135deg, #10b981, #14b8a6);
+        color: #031c1f;
+        border: none;
+        border-radius: 999px;
+        padding: 0.75rem 1.75rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+        &:hover {
+          transform: translateY(-1px);
+          box-shadow: 0 15px 30px rgba(20, 184, 166, 0.35);
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+          box-shadow: none;
+        }
+
+        .loader {
+          width: 16px;
+          height: 16px;
+          border: 3px solid rgba(3, 28, 31, 0.15);
+          border-top-color: #031c1f;
+          border-radius: 50%;
+          animation: spin 0.8s linear infinite;
+        }
+      }
+    }
+
+    .tips {
+      margin-top: 2rem;
+      padding: 1.25rem;
+      border-radius: 1rem;
+      background: rgba(14, 165, 233, 0.12);
+      border: 1px solid rgba(59, 130, 246, 0.18);
+
+      h3 {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        color: #bae6fd;
+        margin-bottom: 0.75rem;
+
+        fa-icon {
+          color: #38bdf8;
+        }
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 0.5rem;
+        font-size: 0.9rem;
+        color: rgba(224, 231, 255, 0.9);
+      }
+    }
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/app/pages/user-profile/user-profile.ts
+++ b/frontend/src/app/pages/user-profile/user-profile.ts
@@ -1,0 +1,264 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NavbarComponent } from '../navbar/navbar';
+import { FooterComponent } from '../footer/footer';
+import { AuthService, ProfileResponse, User } from '../../services/auth.service';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { HttpClient } from '@angular/common/http';
+import {
+  faCamera,
+  faFloppyDisk,
+  faRotateLeft,
+  faShieldHalved,
+  faLock,
+  faBell,
+  faTrash,
+  faCircleInfo,
+} from '@fortawesome/free-solid-svg-icons';
+import { Subscription, lastValueFrom } from 'rxjs';
+
+@Component({
+  selector: 'app-user-profile',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, NavbarComponent, FooterComponent, FontAwesomeModule],
+  templateUrl: './user-profile.html',
+  styleUrls: ['./user-profile.scss'],
+})
+export class UserProfile implements OnInit, OnDestroy {
+  profileForm: FormGroup;
+  passwordForm: FormGroup;
+  user: User | null = null;
+  loadingProfile = false;
+  loadingPassword = false;
+  successMessage: string | null = null;
+  passwordMessage: string | null = null;
+  errorMessage: string | null = null;
+  passwordError: string | null = null;
+  avatarPreview: string | null = null;
+  avatarFile: File | null = null;
+  removeAvatar = false;
+  private subscriptions: Subscription[] = [];
+  private initialProfile: Partial<User> | null = null;
+
+  // Icons
+  faCamera = faCamera;
+  faFloppyDisk = faFloppyDisk;
+  faRotateLeft = faRotateLeft;
+  faShieldHalved = faShieldHalved;
+  faLock = faLock;
+  faBell = faBell;
+  faTrash = faTrash;
+  faCircleInfo = faCircleInfo;
+
+  private readonly cloudinaryUploadUrl = 'https://api.cloudinary.com/v1_1/da80v8vj1/image/upload';
+  private readonly cloudinaryUploadPreset = 'utnentradas';
+
+  constructor(
+    private fb: FormBuilder,
+    private authService: AuthService,
+    private http: HttpClient
+  ) {
+    this.profileForm = this.fb.group({
+      name: ['', [Validators.required, Validators.maxLength(100)]],
+      email: ['', [Validators.required, Validators.email]],
+      phone: ['', [Validators.maxLength(30)]],
+      bio: ['', [Validators.maxLength(500)]],
+      email_notifications: [true],
+    });
+
+    this.passwordForm = this.fb.group({
+      current_password: ['', [Validators.required]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      password_confirmation: ['', [Validators.required, Validators.minLength(8)]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadProfile();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((sub) => sub.unsubscribe());
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+  }
+
+  loadProfile(): void {
+    const sub = this.authService.getUser().subscribe({
+      next: (user) => {
+        this.user = user;
+        this.initialProfile = { ...user };
+        this.avatarPreview = user.avatar_url;
+        this.avatarFile = null;
+        this.removeAvatar = false;
+        this.profileForm.patchValue({
+          name: user.name,
+          email: user.email,
+          phone: user.phone || '',
+          bio: user.bio || '',
+          email_notifications: user.email_notifications,
+        });
+      },
+      error: () => {
+        this.errorMessage = 'No se pudo cargar tu perfil. Intenta nuevamente.';
+      },
+    });
+
+    this.subscriptions.push(sub);
+  }
+
+  async onProfileSubmit(): Promise<void> {
+    if (this.profileForm.invalid) {
+      this.profileForm.markAllAsTouched();
+      return;
+    }
+
+    this.loadingProfile = true;
+    this.successMessage = null;
+    this.errorMessage = null;
+
+    const values = this.profileForm.value;
+    const payload: any = {
+      name: values.name,
+      email: values.email,
+      phone: values.phone ?? '',
+      bio: values.bio ?? '',
+      email_notifications: !!values.email_notifications,
+    };
+
+    if (typeof payload.phone === 'string' && payload.phone.trim() === '') {
+      payload.phone = null;
+    }
+
+    if (typeof payload.bio === 'string' && payload.bio.trim() === '') {
+      payload.bio = null;
+    }
+
+    if (this.removeAvatar) {
+      payload.remove_avatar = true;
+    }
+
+    try {
+      if (this.avatarFile) {
+        const cloudinaryData = new FormData();
+        cloudinaryData.append('file', this.avatarFile);
+        cloudinaryData.append('upload_preset', this.cloudinaryUploadPreset);
+
+        const uploadResponse: any = await lastValueFrom(
+          this.http.post(this.cloudinaryUploadUrl, cloudinaryData)
+        );
+
+        payload.avatar_url = uploadResponse.secure_url;
+      }
+
+      const res: ProfileResponse = await lastValueFrom(this.authService.updateProfile(payload));
+
+      this.successMessage = res.message || 'Perfil actualizado correctamente.';
+      this.user = res.user;
+      this.initialProfile = { ...res.user };
+      this.profileForm.patchValue({
+        name: res.user.name,
+        email: res.user.email,
+        phone: res.user.phone || '',
+        bio: res.user.bio || '',
+        email_notifications: res.user.email_notifications,
+      });
+
+      if (this.avatarPreview && this.avatarFile) {
+        URL.revokeObjectURL(this.avatarPreview);
+      }
+
+      this.avatarPreview = res.user.avatar_url;
+      this.avatarFile = null;
+      this.removeAvatar = false;
+    } catch (err: any) {
+      this.errorMessage = err?.error?.message || 'No se pudo actualizar el perfil.';
+    } finally {
+      this.loadingProfile = false;
+    }
+  }
+
+  onPasswordSubmit(): void {
+    this.passwordError = null;
+    this.passwordMessage = null;
+
+    if (this.passwordForm.invalid) {
+      this.passwordForm.markAllAsTouched();
+      return;
+    }
+
+    const { current_password, password, password_confirmation } = this.passwordForm.value;
+    if (password !== password_confirmation) {
+      this.passwordError = 'Las contraseñas nuevas no coinciden.';
+      return;
+    }
+
+    this.loadingPassword = true;
+
+    const sub = this.authService
+      .updateProfile({ current_password, password, password_confirmation })
+      .subscribe({
+        next: (res) => {
+          this.loadingPassword = false;
+          this.passwordMessage = res.message || 'Contraseña actualizada correctamente.';
+          this.passwordForm.reset();
+        },
+        error: (err) => {
+          this.loadingPassword = false;
+          this.passwordError = err.error?.message || 'No se pudo actualizar la contraseña.';
+        },
+      });
+
+    this.subscriptions.push(sub);
+  }
+
+  onAvatarChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+
+    this.avatarFile = file;
+    this.avatarPreview = URL.createObjectURL(file);
+    this.removeAvatar = false;
+  }
+
+  clearAvatar(): void {
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+
+    this.avatarFile = null;
+    this.avatarPreview = null;
+    this.removeAvatar = true;
+  }
+
+  resetProfile(): void {
+    if (!this.initialProfile) {
+      return;
+    }
+
+    this.profileForm.patchValue({
+      name: this.initialProfile.name ?? '',
+      email: this.initialProfile.email ?? '',
+      phone: this.initialProfile.phone ?? '',
+      bio: this.initialProfile.bio ?? '',
+      email_notifications: this.initialProfile.email_notifications ?? true,
+    });
+    this.errorMessage = null;
+    this.successMessage = null;
+    if (this.avatarPreview && this.avatarFile) {
+      URL.revokeObjectURL(this.avatarPreview);
+    }
+    this.avatarFile = null;
+    this.avatarPreview = this.initialProfile.avatar_url ?? null;
+    this.removeAvatar = false;
+  }
+}

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -9,6 +9,11 @@ export interface User {
   email: string;
   role: string;
   is_verified: boolean;
+  phone: string | null;
+  bio: string | null;
+  avatar_url: string | null;
+  email_notifications: boolean;
+  is_active: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -23,32 +28,38 @@ export interface RegisterResponse {
   user: User;
 }
 
+export interface ProfileResponse {
+  message: string;
+  user: User;
+}
+
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  private apiUrl = 'http://localhost:8000/api/auth';
+  private readonly baseUrl = 'http://localhost:8000/api';
+  private readonly authUrl = `${this.baseUrl}/auth`;
 
   constructor(private http: HttpClient) {}
 
   register(data: { name: string; email: string; password: string }): Observable<RegisterResponse> {
-    return this.http.post<RegisterResponse>(`${this.apiUrl}/register`, data).pipe(
+    return this.http.post<RegisterResponse>(`${this.authUrl}/register`, data).pipe(
       tap((res: RegisterResponse) => {
         localStorage.setItem('token', res.token);
         localStorage.setItem('userId', res.user.id.toString());
         localStorage.setItem('role', res.user.role);
-        localStorage.setItem('email', res.user.email); 
+        localStorage.setItem('email', res.user.email);
       })
     );
   }
 
   login(data: { email: string; password: string }): Observable<LoginResponse> {
-    return this.http.post<LoginResponse>(`${this.apiUrl}/login`, data).pipe(
+    return this.http.post<LoginResponse>(`${this.authUrl}/login`, data).pipe(
       tap((res: LoginResponse) => {
         localStorage.setItem('token', res.token);
         localStorage.setItem('userId', res.user.id.toString());
         localStorage.setItem('role', res.user.role);
-        localStorage.setItem('email', res.user.email); 
+        localStorage.setItem('email', res.user.email);
       })
     );
   }
@@ -57,12 +68,39 @@ export class AuthService {
     localStorage.removeItem('token');
     localStorage.removeItem('userId');
     localStorage.removeItem('role');
-    localStorage.removeItem('email'); 
+    localStorage.removeItem('email');
   }
 
   getUser(): Observable<User> {
     const token = localStorage.getItem('token') || '';
     const headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
-    return this.http.get<User>(`${this.apiUrl}/me`, { headers });
+    return this.http.get<User>(`${this.authUrl}/me`, { headers });
+  }
+
+  updateProfile(data: FormData | Partial<User> & {
+    current_password?: string;
+    password?: string;
+    password_confirmation?: string;
+    remove_avatar?: boolean;
+  }): Observable<ProfileResponse> {
+    const token = localStorage.getItem('token') || '';
+    let headers = new HttpHeaders({ Authorization: `Bearer ${token}` });
+
+    const body = data instanceof FormData ? data : JSON.stringify(data);
+    if (!(data instanceof FormData)) {
+      headers = headers.set('Content-Type', 'application/json');
+    }
+
+    return this.http.request<ProfileResponse>('PATCH', `${this.authUrl}/profile`, {
+      body,
+      headers,
+    }).pipe(
+      tap((res) => {
+        if (res?.user) {
+          localStorage.setItem('role', res.user.role);
+          localStorage.setItem('email', res.user.email);
+        }
+      })
+    );
   }
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,5 +1,559 @@
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-    
+
+:root {
+  --neo-bg: #0b1120;
+  --neo-surface: rgba(15, 23, 42, 0.82);
+  --neo-border: rgba(45, 212, 191, 0.12);
+  --neo-shadow: rgba(15, 23, 42, 0.45);
+  --neo-text: #e2e8f0;
+  --neo-muted: rgba(148, 163, 184, 0.82);
+  --neo-accent: #14b8a6;
+  --neo-accent-strong: #10b981;
+  --neo-accent-blue: #38bdf8;
+  --neo-error: #f87171;
+  --neo-error-soft: rgba(248, 113, 113, 0.18);
+  --neo-success: #4ade80;
+  --neo-success-soft: rgba(22, 163, 74, 0.18);
+  --neo-warning: #facc15;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', 'Poppins', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background: #020617;
+  color: var(--neo-text);
+  min-height: 100vh;
+}
+
+a {
+  color: var(--neo-accent-blue);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: #0ea5e9;
+}
+
+.neo-page {
+  min-height: calc(100vh - 140px);
+  background: radial-gradient(circle at 20% 20%, rgba(0, 213, 139, 0.08), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(34, 211, 238, 0.08), transparent 60%),
+    var(--neo-bg);
+  padding: 4rem 1.5rem;
+  color: var(--neo-text);
+}
+
+.neo-page--full {
+  min-height: 100vh;
+}
+
+.neo-page--with-nav {
+  padding-top: 3rem;
+}
+
+.neo-wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.neo-wrapper--narrow {
+  max-width: 520px;
+}
+
+.neo-wrapper--medium {
+  max-width: 860px;
+}
+
+.neo-wrapper--wide {
+  max-width: 1200px;
+}
+
+.neo-card {
+  background: var(--neo-surface);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid var(--neo-border);
+  box-shadow: 0 30px 60px var(--neo-shadow);
+  backdrop-filter: blur(10px);
+  position: relative;
+  overflow: hidden;
+}
+
+.neo-card--accent {
+  border-color: rgba(56, 189, 248, 0.35);
+  box-shadow: 0 28px 60px rgba(14, 165, 233, 0.22);
+}
+
+.neo-card--inset {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(45, 212, 191, 0.2);
+}
+
+.neo-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  margin-bottom: 1.75rem;
+}
+
+.neo-card__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: var(--neo-accent);
+}
+
+.neo-card__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.4vw, 2.6rem);
+  color: #f8fafc;
+  font-weight: 700;
+}
+
+.neo-card__subtitle {
+  margin: 0;
+  color: var(--neo-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.neo-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.neo-form__grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.neo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.neo-field--full {
+  grid-column: 1 / -1;
+}
+
+.neo-field span {
+  font-size: 0.9rem;
+  color: var(--neo-muted);
+}
+
+.neo-field__control {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid var(--neo-border);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.neo-field__control:focus-within {
+  border-color: rgba(16, 185, 129, 0.65);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.18);
+  background: rgba(15, 23, 42, 0.95);
+}
+
+.neo-field__control input,
+.neo-field__control textarea,
+.neo-field__control select {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--neo-text);
+  font-size: 1rem;
+  font-family: inherit;
+  min-width: 0;
+}
+
+.neo-field__control input:focus,
+.neo-field__control textarea:focus,
+.neo-field__control select:focus {
+  outline: none;
+}
+
+.neo-field__icon {
+  color: var(--neo-accent);
+  font-size: 1.05rem;
+}
+
+.neo-field small {
+  color: #fca5a5;
+  font-size: 0.75rem;
+}
+
+.neo-field textarea {
+  resize: vertical;
+}
+
+.neo-upload {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.3rem;
+  border-radius: 999px;
+  border: 1px dashed rgba(56, 189, 248, 0.45);
+  background: rgba(2, 132, 199, 0.12);
+  color: #bae6fd;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.neo-upload input {
+  display: none;
+}
+
+.neo-upload:hover {
+  border-color: rgba(56, 189, 248, 0.65);
+  background: rgba(2, 132, 199, 0.18);
+}
+
+.neo-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  border-radius: 999px;
+  padding: 0.75rem 1.85rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  border: none;
+}
+
+.neo-button--primary {
+  background: linear-gradient(135deg, var(--neo-accent-strong), var(--neo-accent));
+  color: #021411;
+  box-shadow: 0 18px 40px rgba(20, 184, 166, 0.35);
+}
+
+.neo-button--primary:hover {
+  transform: translateY(-1px);
+}
+
+.neo-button--ghost {
+  background: rgba(14, 165, 233, 0.15);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: #38bdf8;
+}
+
+.neo-button--ghost:hover {
+  background: rgba(56, 189, 248, 0.22);
+}
+
+.neo-button--danger {
+  background: rgba(239, 68, 68, 0.18);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  color: var(--neo-error);
+}
+
+.neo-button--danger:hover {
+  background: rgba(239, 68, 68, 0.24);
+}
+
+.neo-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.neo-text--muted {
+  color: var(--neo-muted);
+  font-size: 0.9rem;
+}
+
+.neo-link {
+  color: #5eead4;
+  font-weight: 600;
+}
+
+.neo-link:hover {
+  color: #34d399;
+}
+
+.neo-feedback {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  font-size: 0.9rem;
+}
+
+.neo-feedback--info {
+  background: rgba(14, 165, 233, 0.15);
+  color: #bae6fd;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.neo-feedback--success {
+  background: var(--neo-success-soft);
+  color: var(--neo-success);
+  border: 1px solid rgba(74, 222, 128, 0.4);
+}
+
+.neo-feedback--error {
+  background: var(--neo-error-soft);
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+}
+
+.neo-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.neo-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding-left: 1.2rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.neo-table-container {
+  overflow-x: auto;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.neo-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.neo-table thead {
+  background: rgba(15, 23, 42, 0.92);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.neo-table th,
+.neo-table td {
+  padding: 0.9rem 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  text-align: left;
+}
+
+.neo-table tbody tr:hover {
+  background: rgba(15, 23, 42, 0.88);
+}
+
+.neo-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.neo-badge--success {
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--neo-success);
+  border: 1px solid rgba(74, 222, 128, 0.35);
+}
+
+.neo-badge--warning {
+  background: rgba(250, 204, 21, 0.12);
+  color: var(--neo-warning);
+  border: 1px solid rgba(250, 204, 21, 0.3);
+}
+
+.neo-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.neo-chip {
+  background: rgba(14, 165, 233, 0.12);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: #bae6fd;
+  border: 1px solid rgba(14, 165, 233, 0.25);
+}
+
+.neo-divider {
+  width: 100%;
+  height: 1px;
+  background: rgba(148, 163, 184, 0.15);
+  margin: 1.5rem 0;
+}
+
+.neo-section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #f1f5f9;
+}
+
+.neo-section-title fa-icon {
+  color: var(--neo-accent);
+}
+
+.neo-hero {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.neo-hero__title {
+  font-size: clamp(2.3rem, 4vw, 3rem);
+  color: #f8fafc;
+  margin: 0;
+}
+
+.neo-hero__subtitle {
+  margin: 0 auto;
+  max-width: 680px;
+  color: var(--neo-muted);
+  font-size: 1rem;
+}
+
+.neo-select {
+  position: relative;
+  min-width: 240px;
+}
+
+.neo-select__button {
+  width: 100%;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid var(--neo-border);
+  color: var(--neo-text);
+  padding: 0.65rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.neo-select__button:hover,
+.neo-select--open .neo-select__button {
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.18);
+}
+
+.neo-select__list {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1rem;
+  border: 1px solid rgba(56, 189, 248, 0.22);
+  box-shadow: 0 24px 45px rgba(15, 23, 42, 0.45);
+  padding: 0.5rem 0;
+  z-index: 40;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.neo-select__option {
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.neo-select__option:hover {
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.neo-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.neo-toggle input {
+  display: none;
+}
+
+.neo-toggle__slider {
+  width: 58px;
+  height: 30px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  position: relative;
+  transition: background 0.25s ease;
+}
+
+.neo-toggle__slider::after {
+  content: '';
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  top: 3px;
+  left: 4px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.neo-toggle input:checked + .neo-toggle__slider {
+  background: rgba(16, 185, 129, 0.5);
+}
+
+.neo-toggle input:checked + .neo-toggle__slider::after {
+  transform: translateX(26px);
+  background: var(--neo-accent-strong);
+}
+
+.neo-loader {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.18);
+  border-top-color: rgba(15, 118, 110, 0.95);
+  animation: neo-spin 0.8s linear infinite;
+}
+
+@keyframes neo-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 640px) {
+  .neo-page {
+    padding: 3rem 1rem;
+  }
+
+  .neo-wrapper {
+    gap: 2rem;
+  }
+
+  .neo-card {
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared "neo" visual theme with reusable card, form, button, table, and feedback styles
- restyle login, register, home, create-event, and ticket-scanner pages (and their controllers) to use the new look and consistent UI affordances
- document the authenticated profile endpoints in Swagger, including field coverage for `/auth/me` and `/auth/profile`

## Testing
- npm run build *(fails: Angular CLI bundle exceeds existing size budgets and surfaces pre-existing NgIf/CommonModule warnings)*

------
https://chatgpt.com/codex/tasks/task_e_690a11f17e088332837159dcb36474ab